### PR TITLE
Handle init error

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,19 @@ And a corresponding React component:
 import { SocketProvider, useTopic } from "@topical/react";
 
 function TodoList({ id }) {
-  const [list, { execute }] = useTopic("lists", id);
+  const [list, { execute, loading, error }] = useTopic("lists", id);
   const handleAddClick = useCallback(
     () => execute("add_item", prompt()),
     [execute]
   );
-  if (list) {
-    return ...;
-  } else {
+  if (loading) {
     return <p>Loading...</p>;
+  } else if (error) {
+    return <p>Error.</p>
+  } else {
+    return (
+      // ...
+    );
   }
 }
 

--- a/client_js/CHANGELOG.md
+++ b/client_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.2.1
+
+### Fixes
+
+- Doesn't try to unsubscribe after a subscription error.
+
 ## 0.2.0
 
 ### Improvements

--- a/client_js/package-lock.json
+++ b/client_js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@topical/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@topical/core",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0"
     }
   }

--- a/client_js/package.json
+++ b/client_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topical/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Vanilla Topical client.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/client_js/src/socket.ts
+++ b/client_js/src/socket.ts
@@ -112,15 +112,17 @@ export default class Socket {
       }
     }
     return () => {
-      const { listeners, channelId } = this.topics[key];
-      const index = listeners.indexOf(listener);
-      listeners.splice(index, 1);
-      if (!listeners.length) {
-        if (channelId && this.isConnected()) {
-          this.socket.send(JSON.stringify([3, channelId]));
-          delete this.subscriptions[channelId];
+      if (key in this.topics) {
+        const { listeners, channelId } = this.topics[key];
+        const index = listeners.indexOf(listener);
+        listeners.splice(index, 1);
+        if (!listeners.length) {
+          if (channelId && this.isConnected()) {
+            this.socket.send(JSON.stringify([3, channelId]));
+            delete this.subscriptions[channelId];
+          }
+          delete this.topics[key];
         }
-        delete this.topics[key];
       }
     };
   }

--- a/client_react/CHANGELOG.md
+++ b/client_react/CHANGELOG.md
@@ -1,10 +1,16 @@
 # CHANGELOG
 
+## 0.3.0
+
+### Improvements
+
+- `useTopic` now returns stale value, along with an `error` and `loading` properties.
+
 ## 0.2.0
 
 ### Improvements
 
-- Updaated core dependency to add support for merge operations.
+- Updated core dependency to add support for merge operations.
 
 ## 0.1.9
 

--- a/client_react/package-lock.json
+++ b/client_react/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@topical/core": "^0.2.0",
-        "react": "^18.2.0"
+        "@topical/core": "^0.2.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.26"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
       }
     },
     "node_modules/@topical/core": {
@@ -53,12 +55,14 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -70,6 +74,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -116,12 +121,14 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -130,6 +137,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/client_react/package-lock.json
+++ b/client_react/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@topical/react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@topical/react",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@topical/core": "^0.2.0"
+        "@topical/core": "^0.2.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.26"
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@topical/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@topical/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-OnwUq4kp5h7KNOJJjUALEZhzL7CrXofQZjox8RtET6PyJzBi2RH8GhbrLzyCCJA568R8pHpWOI9RlXLi5ACaaQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@topical/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-DGfa8os8MSu7nUAgkss2TWbZf6/jCyhe7p6wT2w78uRBzm8qEEb2XSE4pCNhK4b3C0/2bLPuTLwEIwe9clsXLA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -85,9 +85,9 @@
   },
   "dependencies": {
     "@topical/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@topical/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-OnwUq4kp5h7KNOJJjUALEZhzL7CrXofQZjox8RtET6PyJzBi2RH8GhbrLzyCCJA568R8pHpWOI9RlXLi5ACaaQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@topical/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-DGfa8os8MSu7nUAgkss2TWbZf6/jCyhe7p6wT2w78uRBzm8qEEb2XSE4pCNhK4b3C0/2bLPuTLwEIwe9clsXLA=="
     },
     "@types/prop-types": {
       "version": "15.7.5",

--- a/client_react/package.json
+++ b/client_react/package.json
@@ -21,7 +21,9 @@
     "dist"
   ],
   "dependencies": {
-    "@topical/core": "^0.2.0",
+    "@topical/core": "^0.2.0"
+  },
+  "peerDependencies": {
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/client_react/package.json
+++ b/client_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topical/react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React Topical client.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -20,13 +20,13 @@
   "files": [
     "dist"
   ],
-  "dependencies": {
-    "@topical/core": "^0.2.0"
-  },
   "peerDependencies": {
     "react": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.26"
+  },
+  "dependencies": {
+    "@topical/core": "^0.2.1"
   }
 }

--- a/client_react/src/useSocket.ts
+++ b/client_react/src/useSocket.ts
@@ -5,7 +5,7 @@ import { Context } from "./provider";
 
 export default function useSocket(): [
   Socket | undefined,
-  SocketState | undefined
+  SocketState | undefined,
 ] {
   const socket = useContext(Context);
   const [state, setState] = useState<SocketState>();

--- a/client_react/src/useTopic.ts
+++ b/client_react/src/useTopic.ts
@@ -12,6 +12,7 @@ export default function useTopic<T>(...topicParts: (string | undefined)[]): [
     notify: (action: string, ...args: any[]) => void;
     execute: (action: string, ...args: any[]) => Promise<any>;
     error: any;
+    loading: boolean;
   },
 ] {
   const socket = useContext(Context);
@@ -38,10 +39,7 @@ export default function useTopic<T>(...topicParts: (string | undefined)[]): [
       );
     }
   }, [socket, ...topicParts]);
-  if (state && arrayEqual(topicParts, state[0])) {
-    const [_, value, error] = state;
-    return [value, { notify, execute, error }];
-  } else {
-    return [undefined, { notify, execute, error: undefined }];
-  }
+  const [stateTopic, value, error] = state || [undefined, undefined, undefined];
+  const loading = !stateTopic || !arrayEqual(topicParts, stateTopic);
+  return [value, { notify, execute, error, loading }];
 }

--- a/client_react/src/useTopic.ts
+++ b/client_react/src/useTopic.ts
@@ -11,7 +11,7 @@ export default function useTopic<T>(...topicParts: (string | undefined)[]): [
   {
     notify: (action: string, ...args: any[]) => void;
     execute: (action: string, ...args: any[]) => Promise<any>;
-  }
+  },
 ] {
   const socket = useContext(Context);
   const [state, setState] =
@@ -20,20 +20,20 @@ export default function useTopic<T>(...topicParts: (string | undefined)[]): [
     (action: string, ...args: any[]) => {
       return socket!.notify(topicParts, action, ...args);
     },
-    [socket, ...topicParts]
+    [socket, ...topicParts],
   );
   const execute = useCallback(
     (action: string, ...args: any[]) => {
       return socket!.execute(topicParts, action, ...args);
     },
-    [socket, ...topicParts]
+    [socket, ...topicParts],
   );
   useEffect(() => {
     if (!topicParts.some((p) => typeof p == "undefined")) {
       return socket?.subscribe<T>(
         topicParts,
         (v) => setState([topicParts, v, undefined]),
-        (e) => setState([topicParts, undefined, e])
+        (e) => setState([topicParts, undefined, e]),
       );
     }
   }, [socket, ...topicParts]);

--- a/client_react/src/useTopic.ts
+++ b/client_react/src/useTopic.ts
@@ -11,6 +11,7 @@ export default function useTopic<T>(...topicParts: (string | undefined)[]): [
   {
     notify: (action: string, ...args: any[]) => void;
     execute: (action: string, ...args: any[]) => Promise<any>;
+    error: any;
   },
 ] {
   const socket = useContext(Context);
@@ -39,11 +40,8 @@ export default function useTopic<T>(...topicParts: (string | undefined)[]): [
   }, [socket, ...topicParts]);
   if (state && arrayEqual(topicParts, state[0])) {
     const [_, value, error] = state;
-    if (error) {
-      throw new Error(error);
-    }
-    return [value, { notify, execute }];
+    return [value, { notify, execute, error }];
   } else {
-    return [undefined, { notify, execute }];
+    return [undefined, { notify, execute, error: undefined }];
   }
 }

--- a/server_ex/docs/javascript-client.md
+++ b/server_ex/docs/javascript-client.md
@@ -72,17 +72,19 @@ Then use the `useTopic` hook in your components to subscribe to your topic:
 import { useTopic } from "@topical/react";
 
 function List({ id }) {
-  const [list, { execute, notify }] = useTopic<models.List>("lists", id);
+  const [list, { execute, notify, loading, error }] = useTopic<models.List>("lists", id);
   const addItem = useCallback(
     (text: string) => execute("add_item", text),
     [execute]
   );
-  if (list) {
+  if (loading) {
+    return <p>Loading...</p>;
+  } else if (error) {
+    return <p>Error.</p>
+  } else {
     return (
       // ...
     );
-  } else {
-    return <p>Loading...</p>
   }
 }
 ```

--- a/server_ex/lib/topical/adapters/base/websocket.ex
+++ b/server_ex/lib/topical/adapters/base/websocket.ex
@@ -91,8 +91,8 @@ defmodule Topical.Adapters.Base.WebSocket do
 
         {:ok, [], state}
 
-      {:error, :not_found} ->
-        {:ok, [Response.encode_error(channel_id, "not_found")], state}
+      {:error, error} ->
+        {:ok, [Response.encode_error(channel_id, error)], state}
     end
   end
 


### PR DESCRIPTION
This updates the server to handle initialisation errors, and pass these back to the client. And hence updates the client to expose these errors.

Additionally, this updates the React client to return potentially stale state from the hook, along with an additional `loading` property (and an `error` property). The `loading` flag should be used to determine whether the value is stale. This change makes it easier for a UI to avoid 'flashing' between topic changes.