### PR TITLE
Fix deprecation warning

### DIFF
--- a/server_ex/CHANGELOG.md
+++ b/server_ex/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.3
+
+### Improvements
+
+- Fixes deprecation warning.
 
 ## 0.2.2
 

--- a/server_ex/lib/topical/registry.ex
+++ b/server_ex/lib/topical/registry.ex
@@ -17,22 +17,21 @@ defmodule Topical.Registry do
     )
   end
 
-  defp build_routes(modules) do
-    Enum.map(modules, fn module ->
-      route =
-        if is_binary(module.route) do
-          module.route
-          |> String.split("/")
-          |> Enum.map(fn
-            ":" <> atom -> String.to_atom(atom)
-            part -> URI.decode(part)
-          end)
-        else
-          module.route
-        end
+  defp parse_route(route) do
+    if is_binary(route) do
+      route
+      |> String.split("/")
+      |> Enum.map(fn
+        ":" <> atom -> String.to_atom(atom)
+        part -> URI.decode(part)
+      end)
+    else
+      route
+    end
+  end
 
-      {route, module}
-    end)
+  defp build_routes(modules) do
+    Enum.map(modules, &{parse_route(&1.route()), &1})
   end
 
   defp resolve_route(route, routes) do

--- a/server_ex/mix.exs
+++ b/server_ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Topical.MixProject do
   def project do
     [
       app: :topical,
-      version: "0.2.2",
+      version: "0.2.3",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
This fixes a deprecation warning from using `map.field` notation (and tidies the implementation a bit).