### PR TITLE
Support authorisaton callback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: server_ex
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.16"
+          otp-version: "26"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            server_ex/deps
+            server_ex/_build
+          key: ${{ runner.os }}-mix-${{ hashFiles('server_ex/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Check unused deps
+        run: mix deps.unlock --check-unused
+
+      - name: Compile
+        run: mix compile --warnings-as-errors
+
+      - name: Run tests
+        run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 
@@ -47,3 +48,60 @@ jobs:
 
       - name: Run tests
         run: mix test
+
+  release:
+    name: Release to Hex
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: server_ex
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.16"
+          otp-version: "26"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            server_ex/deps
+            server_ex/_build
+          key: ${{ runner.os }}-mix-${{ hashFiles('server_ex/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Verify tag matches mix.exs version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          MIX_VERSION=$(grep 'version:' mix.exs | sed 's/.*version: "\(.*\)".*/\1/')
+          echo "Tag version: $TAG_VERSION"
+          echo "mix.exs version: $MIX_VERSION"
+          if [ "$TAG_VERSION" != "$MIX_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match mix.exs version ($MIX_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish to Hex
+        run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+
+      - name: Publish docs to HexDocs
+        run: mix hex.publish docs --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/server_ex/CHANGELOG.md
+++ b/server_ex/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.2.4
+
+### Features
+
+- Adds `authorize/2` callback for controlling access to topics based on context.
+
 ## 0.2.3
 
 ### Improvements

--- a/server_ex/docs/getting-started.md
+++ b/server_ex/docs/getting-started.md
@@ -53,6 +53,35 @@ defmodule MyApp.Topics.List do
 end
 ```
 
+## Authorization
+
+You can control access to topics by implementing the `authorize/2` callback. This is called
+before a topic is accessed (via subscribe, execute, notify, or capture). The callback receives
+the route params and the context (established during WebSocket connection):
+
+```elixir
+defmodule MyApp.Topics.PrivateList do
+  use Topical.Topic, route: ["lists", :list_id]
+
+  def authorize(params, context) do
+    list_id = Keyword.fetch!(params, :list_id)
+
+    if can_access_list?(context.user_id, list_id) do
+      :ok
+    else
+      {:error, :forbidden}
+    end
+  end
+
+  # ... other callbacks
+end
+```
+
+Return `:ok` to allow access, or `{:error, reason}` to deny. The default implementation
+allows all access.
+
+## Supervision
+
 Then add a Topical registry to your application supervision tree, referencing the topic:
 
 ```elixir

--- a/server_ex/lib/topical.ex
+++ b/server_ex/lib/topical.ex
@@ -44,7 +44,7 @@ defmodule Topical do
 
   """
   def subscribe(registry, topic, pid, context \\ nil) do
-    with {:ok, server} <- Registry.get_topic(registry, topic) do
+    with {:ok, server} <- Registry.get_topic(registry, topic, context) do
       # TODO: monitor/link server?
       {:ok, GenServer.call(server, {:subscribe, pid, context})}
     end
@@ -59,8 +59,7 @@ defmodule Topical do
 
   """
   def unsubscribe(registry, topic, ref) do
-    # TODO: don't start server if not running
-    with {:ok, server} <- Registry.get_topic(registry, topic) do
+    with {:ok, server} <- Registry.lookup_topic(registry, topic) do
       GenServer.cast(server, {:unsubscribe, ref})
     end
   end
@@ -74,7 +73,7 @@ defmodule Topical do
       # => {:ok, %{items: %{}, order: []}}
   """
   def capture(registry, topic, context \\ nil) do
-    with {:ok, server} <- Registry.get_topic(registry, topic) do
+    with {:ok, server} <- Registry.get_topic(registry, topic, context) do
       {:ok, GenServer.call(server, {:capture, context})}
     end
   end
@@ -89,7 +88,7 @@ defmodule Topical do
 
   """
   def execute(registry, topic, action, args \\ {}, context \\ nil) do
-    with {:ok, server} <- Registry.get_topic(registry, topic) do
+    with {:ok, server} <- Registry.get_topic(registry, topic, context) do
       {:ok, GenServer.call(server, {:execute, action, args, context})}
     end
   end
@@ -106,7 +105,7 @@ defmodule Topical do
 
   """
   def notify(registry, topic, action, args \\ {}, context \\ nil) do
-    with {:ok, server} <- Registry.get_topic(registry, topic) do
+    with {:ok, server} <- Registry.get_topic(registry, topic, context) do
       GenServer.cast(server, {:notify, action, args, context})
     end
   end

--- a/server_ex/lib/topical/topic.ex
+++ b/server_ex/lib/topical/topic.ex
@@ -84,6 +84,10 @@ defmodule Topical.Topic do
         unquote(Keyword.fetch!(opts, :route))
       end
 
+      def authorize(_params, _context) do
+        :ok
+      end
+
       def handle_subscribe(topic, _context) do
         {:ok, topic}
       end
@@ -113,7 +117,8 @@ defmodule Topical.Topic do
         :ok
       end
 
-      defoverridable handle_subscribe: 2,
+      defoverridable authorize: 2,
+                     handle_subscribe: 2,
                      handle_unsubscribe: 2,
                      handle_capture: 2,
                      handle_execute: 4,

--- a/server_ex/lib/topical/topic/server.ex
+++ b/server_ex/lib/topical/topic/server.ex
@@ -8,6 +8,18 @@ defmodule Topical.Topic.Server do
   """
 
   @doc """
+  Invoked to check whether a client is authorized to access this topic.
+
+  `params` are the values associated with the placeholders in the route.
+  `context` is the context established during the WebSocket connection.
+
+  Return `:ok` to allow access, or `{:error, reason}` to deny.
+
+  This callback is optional. The default implementation returns `:ok`.
+  """
+  @callback authorize(params :: keyword(), context :: any) :: :ok | {:error, reason :: any}
+
+  @doc """
   Invoked when the topic is started to get the initial state.
 
   `params` are the values associated with the placeholders in the route.

--- a/server_ex/mix.exs
+++ b/server_ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Topical.MixProject do
   def project do
     [
       app: :topical,
-      version: "0.2.3",
+      version: "0.2.4",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/server_ex/test/integration_test.exs
+++ b/server_ex/test/integration_test.exs
@@ -1,0 +1,417 @@
+defmodule Topical.IntegrationTest do
+  use ExUnit.Case
+
+  setup do
+    registry_name = :"integration_registry_#{System.unique_integer([:positive])}"
+
+    start_supervised!(%{
+      id: registry_name,
+      start:
+        {Topical.Registry, :start_link,
+         [
+           [
+             name: registry_name,
+             topics: [
+               Topical.Test.CounterTopic,
+               Topical.Test.AuthorizedTopic,
+               Topical.Test.CallbackTopic,
+               Topical.Test.FailingTopic,
+               Topical.Test.ListTopic,
+               Topical.Test.MergeTopic
+             ]
+           ]
+         ]}
+    })
+
+    {:ok, registry: registry_name}
+  end
+
+  describe "subscribe/4" do
+    test "subscriber receives reset message", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+
+      assert_receive {:reset, ^ref, %{count: 0}}
+    end
+
+    test "returns ref that matches messages", %{registry: registry} do
+      {:ok, ref1} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref2} = Topical.subscribe(registry, ["counters", "2"], self())
+
+      assert ref1 != ref2
+
+      assert_receive {:reset, ^ref1, _}
+      assert_receive {:reset, ^ref2, _}
+    end
+
+    test "subscriber receives updates after subscribe", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      assert_receive {:reset, ^ref, %{count: 0}}
+
+      Topical.execute(registry, ["counters", "1"], "increment", {})
+
+      assert_receive {:updates, ^ref, [{:set, [:count], 1}]}
+    end
+  end
+
+  describe "unsubscribe/3" do
+    test "stops receiving updates after unsubscribe", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      assert_receive {:reset, ^ref, %{count: 0}}
+
+      :ok = Topical.unsubscribe(registry, ["counters", "1"], ref)
+
+      Topical.execute(registry, ["counters", "1"], "increment", {})
+
+      refute_receive {:updates, _, _}, 100
+    end
+
+    test "returns error for non-running topic", %{registry: registry} do
+      ref = make_ref()
+
+      assert {:error, :not_running} =
+               Topical.unsubscribe(registry, ["counters", "nonexistent"], ref)
+    end
+  end
+
+  describe "execute/5" do
+    test "returns result from topic", %{registry: registry} do
+      {:ok, result} = Topical.execute(registry, ["counters", "1"], "increment", {})
+      assert result == 1
+
+      {:ok, result} = Topical.execute(registry, ["counters", "1"], "increment", {})
+      assert result == 2
+    end
+
+    test "subscribers receive updates from execute", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      assert_receive {:reset, ^ref, %{count: 0}}
+
+      {:ok, _} = Topical.execute(registry, ["counters", "1"], "set", {42})
+
+      assert_receive {:updates, ^ref, [{:set, [:count], 42}]}
+    end
+
+    test "returns error for unknown topic", %{registry: registry} do
+      assert {:error, :not_found} =
+               Topical.execute(registry, ["unknown", "topic"], "action", {})
+    end
+  end
+
+  describe "notify/5" do
+    test "sends notification to topic", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      assert_receive {:reset, ^ref, %{count: 0}}
+
+      :ok = Topical.notify(registry, ["counters", "1"], "increment", {})
+
+      assert_receive {:updates, ^ref, [{:set, [:count], 1}]}
+    end
+
+    test "returns :ok without waiting for result", %{registry: registry} do
+      result = Topical.notify(registry, ["counters", "1"], "set", {100})
+      assert result == :ok
+    end
+
+    test "returns error for unknown topic", %{registry: registry} do
+      assert {:error, :not_found} = Topical.notify(registry, ["unknown", "topic"], "action", {})
+    end
+  end
+
+  describe "capture/3" do
+    test "returns current topic value", %{registry: registry} do
+      Topical.execute(registry, ["counters", "1"], "set", {42})
+
+      {:ok, value} = Topical.capture(registry, ["counters", "1"])
+      assert value == %{count: 42}
+    end
+
+    test "does not subscribe", %{registry: registry} do
+      {:ok, _value} = Topical.capture(registry, ["counters", "1"])
+
+      Topical.execute(registry, ["counters", "1"], "increment", {})
+
+      refute_receive {:updates, _, _}, 100
+    end
+
+    test "returns error for unknown topic", %{registry: registry} do
+      assert {:error, :not_found} = Topical.capture(registry, ["unknown", "topic"])
+    end
+  end
+
+  describe "multiple subscribers" do
+    test "all subscribers receive same updates", %{registry: registry} do
+      {:ok, ref1} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref2} = Topical.subscribe(registry, ["counters", "1"], self())
+
+      assert_receive {:reset, ^ref1, %{count: 0}}
+      assert_receive {:reset, ^ref2, %{count: 0}}
+
+      Topical.execute(registry, ["counters", "1"], "increment", {})
+
+      assert_receive {:updates, ^ref1, [{:set, [:count], 1}]}
+      assert_receive {:updates, ^ref2, [{:set, [:count], 1}]}
+    end
+
+    test "unsubscribing one does not affect others", %{registry: registry} do
+      {:ok, ref1} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref2} = Topical.subscribe(registry, ["counters", "1"], self())
+
+      assert_receive {:reset, ^ref1, _}
+      assert_receive {:reset, ^ref2, _}
+
+      Topical.unsubscribe(registry, ["counters", "1"], ref1)
+      Topical.execute(registry, ["counters", "1"], "increment", {})
+
+      # ref1 should not receive update
+      refute_receive {:updates, ^ref1, _}, 100
+      # ref2 should still receive update
+      assert_receive {:updates, ^ref2, [{:set, [:count], 1}]}
+    end
+  end
+
+  describe "authorization" do
+    test "subscribe respects authorization", %{registry: registry} do
+      assert {:error, :forbidden} =
+               Topical.subscribe(registry, ["private", "owner1"], self(), %{user_id: "other"})
+
+      {:ok, _ref} =
+        Topical.subscribe(registry, ["private", "owner1"], self(), %{user_id: "owner1"})
+    end
+
+    test "execute respects authorization", %{registry: registry} do
+      assert {:error, :forbidden} =
+               Topical.execute(
+                 registry,
+                 ["private", "owner1"],
+                 "get_data",
+                 {},
+                 %{user_id: "other"}
+               )
+
+      {:ok, _} =
+        Topical.execute(registry, ["private", "owner1"], "get_data", {}, %{user_id: "owner1"})
+    end
+
+    test "notify respects authorization", %{registry: registry} do
+      assert {:error, :forbidden} =
+               Topical.notify(
+                 registry,
+                 ["private", "owner1"],
+                 "set_data",
+                 {"test"},
+                 %{user_id: "other"}
+               )
+
+      :ok =
+        Topical.notify(
+          registry,
+          ["private", "owner1"],
+          "set_data",
+          {"test"},
+          %{user_id: "owner1"}
+        )
+    end
+
+    test "capture respects authorization", %{registry: registry} do
+      assert {:error, :forbidden} =
+               Topical.capture(registry, ["private", "owner1"], %{user_id: "other"})
+
+      {:ok, _value} = Topical.capture(registry, ["private", "owner1"], %{user_id: "owner1"})
+    end
+  end
+
+  describe "callback invocations" do
+    test "handle_subscribe is called on subscribe", %{registry: registry} do
+      context = %{user: "test"}
+      {:ok, ref} = Topical.subscribe(registry, ["callbacks", "1"], self(), context)
+
+      assert_receive {:reset, ^ref, %{callbacks: callbacks}}
+      assert [{:subscribe, ^context}] = callbacks
+    end
+
+    test "handle_unsubscribe is called on unsubscribe", %{registry: registry} do
+      context = %{user: "test"}
+      {:ok, ref} = Topical.subscribe(registry, ["callbacks", "1"], self(), context)
+      assert_receive {:reset, ^ref, _}
+
+      Topical.unsubscribe(registry, ["callbacks", "1"], ref)
+
+      # Give time for unsubscribe to process
+      Process.sleep(50)
+
+      {:ok, value} = Topical.capture(registry, ["callbacks", "1"])
+      # Note: capture also adds a {:capture, nil} callback, so check for unsubscribe presence
+      assert Enum.any?(value.callbacks, fn
+        {:unsubscribe, ^context} -> true
+        _ -> false
+      end)
+    end
+
+    test "handle_capture is called on capture", %{registry: registry} do
+      context = %{user: "test"}
+      {:ok, value} = Topical.capture(registry, ["callbacks", "1"], context)
+
+      assert [{:capture, ^context}] = value.callbacks
+    end
+
+    test "handle_execute is called on execute", %{registry: registry} do
+      context = %{user: "test"}
+      {:ok, _} = Topical.execute(registry, ["callbacks", "1"], "action", {"arg"}, context)
+
+      {:ok, value} = Topical.capture(registry, ["callbacks", "1"])
+      # Note: capture also adds a {:capture, nil} callback, so check for execute presence
+      assert Enum.any?(value.callbacks, fn
+        {:execute, {"arg"}, ^context} -> true
+        _ -> false
+      end)
+    end
+
+    test "handle_notify is called on notify", %{registry: registry} do
+      context = %{user: "test"}
+      :ok = Topical.notify(registry, ["callbacks", "1"], "action", {"arg"}, context)
+
+      # Give time for notify to process
+      Process.sleep(50)
+
+      {:ok, value} = Topical.capture(registry, ["callbacks", "1"])
+      # Note: capture also adds a {:capture, nil} callback, so check for notify presence
+      assert Enum.any?(value.callbacks, fn
+        {:notify, {"arg"}, ^context} -> true
+        _ -> false
+      end)
+    end
+  end
+
+  describe "topic timeout" do
+    test "topic stops after timeout with no subscribers", %{registry: registry} do
+      # Start a topic
+      {:ok, _} = Topical.execute(registry, ["counters", "timeout-test"], "increment", {})
+
+      {:ok, pid} = Topical.Registry.lookup_topic(registry, ["counters", "timeout-test"])
+      assert Process.alive?(pid)
+
+      # Wait for timeout (10 seconds is default, but we'll just check the behavior)
+      # We use a reference to monitor the process
+      ref = Process.monitor(pid)
+
+      # Topic should still be running after short delay
+      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 100
+
+      # Clean up
+      Process.demonitor(ref, [:flush])
+    end
+
+    test "topic does not timeout while subscribed", %{registry: registry} do
+      {:ok, sub_ref} = Topical.subscribe(registry, ["counters", "sub-test"], self())
+      assert_receive {:reset, ^sub_ref, _}
+
+      {:ok, pid} = Topical.Registry.lookup_topic(registry, ["counters", "sub-test"])
+      mon_ref = Process.monitor(pid)
+
+      # Should not timeout while subscribed
+      refute_receive {:DOWN, ^mon_ref, :process, ^pid, _}, 200
+
+      Process.demonitor(mon_ref, [:flush])
+    end
+  end
+
+  describe "list operations" do
+    test "insert operations broadcast to subscribers", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["lists", "1"], self())
+      assert_receive {:reset, ^ref, %{items: [], next_id: 1}}
+
+      {:ok, 1} = Topical.execute(registry, ["lists", "1"], "add", {"first"})
+
+      assert_receive {:updates, ^ref, updates}
+      assert {:insert, [:items], nil, [%{id: 1, value: "first"}]} in updates
+    end
+
+    test "delete operations broadcast to subscribers", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["lists", "1"], self())
+      assert_receive {:reset, ^ref, _}
+
+      {:ok, _} = Topical.execute(registry, ["lists", "1"], "add", {"first"})
+      assert_receive {:updates, ^ref, _}
+
+      {:ok, _} = Topical.execute(registry, ["lists", "1"], "add", {"second"})
+      assert_receive {:updates, ^ref, _}
+
+      {:ok, _} = Topical.execute(registry, ["lists", "1"], "remove", {0})
+
+      assert_receive {:updates, ^ref, [{:delete, [:items], 0, 1}]}
+    end
+  end
+
+  describe "merge operations" do
+    test "merge operations broadcast to subscribers", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["merge", "1"], self())
+      assert_receive {:reset, ^ref, %{data: %{}}}
+
+      {:ok, _} = Topical.execute(registry, ["merge", "1"], "merge", {%{a: 1, b: 2}})
+
+      assert_receive {:updates, ^ref, [{:merge, [:data], %{a: 1, b: 2}}]}
+    end
+
+    test "unset operations broadcast to subscribers", %{registry: registry} do
+      {:ok, ref} = Topical.subscribe(registry, ["merge", "1"], self())
+      assert_receive {:reset, ^ref, _}
+
+      {:ok, _} = Topical.execute(registry, ["merge", "1"], "set", {:key, "value"})
+      assert_receive {:updates, ^ref, _}
+
+      {:ok, _} = Topical.execute(registry, ["merge", "1"], "unset", {:key})
+
+      assert_receive {:updates, ^ref, [{:unset, [:data], :key}]}
+    end
+  end
+
+  describe "subscriber process death" do
+    test "subscriber is removed when process dies", %{registry: registry} do
+      # Spawn a process that subscribes then dies
+      test_pid = self()
+
+      subscriber =
+        spawn(fn ->
+          {:ok, _ref} = Topical.subscribe(registry, ["callbacks", "death-test"], self())
+          send(test_pid, :subscribed)
+
+          receive do
+            :die -> :ok
+          end
+        end)
+
+      assert_receive :subscribed
+
+      # Kill the subscriber
+      send(subscriber, :die)
+
+      # Wait for process to die and unsubscribe to be processed
+      Process.sleep(100)
+
+      # Check that unsubscribe was called
+      {:ok, value} = Topical.capture(registry, ["callbacks", "death-test"])
+      # Note: capture also adds a {:capture, nil} callback, so check for unsubscribe presence
+      assert Enum.any?(value.callbacks, fn
+        {:unsubscribe, _} -> true
+        _ -> false
+      end)
+    end
+  end
+
+  describe "child_spec/1" do
+    test "returns valid child spec" do
+      spec = Topical.child_spec(name: MyApp.Topical, topics: [])
+
+      # Default id is Topical when :server option is not provided
+      assert spec.id == Topical
+      assert spec.type == :supervisor
+      assert {Topical.Registry, :start_link, [_opts]} = spec.start
+    end
+
+    test "uses :server option as id when provided" do
+      spec = Topical.child_spec(name: SomeRegistry, server: CustomId, topics: [])
+
+      assert spec.id == CustomId
+    end
+  end
+end

--- a/server_ex/test/integration_test.exs
+++ b/server_ex/test/integration_test.exs
@@ -242,9 +242,9 @@ defmodule Topical.IntegrationTest do
       {:ok, value} = Topical.capture(registry, ["callbacks", "1"])
       # Note: capture also adds a {:capture, nil} callback, so check for unsubscribe presence
       assert Enum.any?(value.callbacks, fn
-        {:unsubscribe, ^context} -> true
-        _ -> false
-      end)
+               {:unsubscribe, ^context} -> true
+               _ -> false
+             end)
     end
 
     test "handle_capture is called on capture", %{registry: registry} do
@@ -261,9 +261,9 @@ defmodule Topical.IntegrationTest do
       {:ok, value} = Topical.capture(registry, ["callbacks", "1"])
       # Note: capture also adds a {:capture, nil} callback, so check for execute presence
       assert Enum.any?(value.callbacks, fn
-        {:execute, {"arg"}, ^context} -> true
-        _ -> false
-      end)
+               {:execute, {"arg"}, ^context} -> true
+               _ -> false
+             end)
     end
 
     test "handle_notify is called on notify", %{registry: registry} do
@@ -276,9 +276,9 @@ defmodule Topical.IntegrationTest do
       {:ok, value} = Topical.capture(registry, ["callbacks", "1"])
       # Note: capture also adds a {:capture, nil} callback, so check for notify presence
       assert Enum.any?(value.callbacks, fn
-        {:notify, {"arg"}, ^context} -> true
-        _ -> false
-      end)
+               {:notify, {"arg"}, ^context} -> true
+               _ -> false
+             end)
     end
   end
 
@@ -392,9 +392,9 @@ defmodule Topical.IntegrationTest do
       {:ok, value} = Topical.capture(registry, ["callbacks", "death-test"])
       # Note: capture also adds a {:capture, nil} callback, so check for unsubscribe presence
       assert Enum.any?(value.callbacks, fn
-        {:unsubscribe, _} -> true
-        _ -> false
-      end)
+               {:unsubscribe, _} -> true
+               _ -> false
+             end)
     end
   end
 

--- a/server_ex/test/support/test_topics.ex
+++ b/server_ex/test/support/test_topics.ex
@@ -1,0 +1,245 @@
+defmodule Topical.Test.CounterTopic do
+  @moduledoc """
+  Simple counter topic for basic testing.
+  Route: ["counters", :id]
+  Actions: "increment", "decrement", "set", "get"
+  """
+  use Topical.Topic, route: ["counters", :id]
+
+  def init(params) do
+    id = Keyword.fetch!(params, :id)
+    value = %{count: 0}
+    state = %{id: id}
+    {:ok, Topic.new(value, state)}
+  end
+
+  def handle_execute("increment", {}, topic, _context) do
+    new_count = topic.value.count + 1
+    topic = Topic.set(topic, [:count], new_count)
+    {:ok, new_count, topic}
+  end
+
+  def handle_execute("decrement", {}, topic, _context) do
+    new_count = topic.value.count - 1
+    topic = Topic.set(topic, [:count], new_count)
+    {:ok, new_count, topic}
+  end
+
+  def handle_execute("set", {value}, topic, _context) do
+    topic = Topic.set(topic, [:count], value)
+    {:ok, value, topic}
+  end
+
+  def handle_execute("get", {}, topic, _context) do
+    {:ok, topic.value.count, topic}
+  end
+
+  def handle_notify("increment", {}, topic, _context) do
+    new_count = topic.value.count + 1
+    topic = Topic.set(topic, [:count], new_count)
+    {:ok, topic}
+  end
+
+  def handle_notify("set", {value}, topic, _context) do
+    topic = Topic.set(topic, [:count], value)
+    {:ok, topic}
+  end
+end
+
+defmodule Topical.Test.AuthorizedTopic do
+  @moduledoc """
+  Topic with authorization logic.
+  Route: ["private", :owner_id]
+  Only allows access when context.user_id == owner_id
+  """
+  use Topical.Topic, route: ["private", :owner_id]
+
+  def authorize(params, context) do
+    owner_id = Keyword.fetch!(params, :owner_id)
+
+    cond do
+      context == nil ->
+        {:error, :unauthorized}
+
+      context[:user_id] == owner_id ->
+        :ok
+
+      true ->
+        {:error, :forbidden}
+    end
+  end
+
+  def init(params) do
+    owner_id = Keyword.fetch!(params, :owner_id)
+    value = %{owner: owner_id, data: nil}
+    {:ok, Topic.new(value)}
+  end
+
+  def handle_execute("get_data", {}, topic, _context) do
+    {:ok, topic.value.data, topic}
+  end
+
+  def handle_execute("set_data", {data}, topic, _context) do
+    topic = Topic.set(topic, [:data], data)
+    {:ok, :ok, topic}
+  end
+
+  def handle_notify("set_data", {data}, topic, _context) do
+    topic = Topic.set(topic, [:data], data)
+    {:ok, topic}
+  end
+end
+
+defmodule Topical.Test.CallbackTopic do
+  @moduledoc """
+  Topic that tracks callback invocations.
+  Used to verify callback order and arguments.
+  Route: ["callbacks", :id]
+  """
+  use Topical.Topic, route: ["callbacks", :id]
+
+  def init(params) do
+    id = Keyword.fetch!(params, :id)
+    value = %{callbacks: []}
+    state = %{id: id}
+    {:ok, Topic.new(value, state)}
+  end
+
+  def handle_subscribe(topic, context) do
+    callbacks = topic.value.callbacks ++ [{:subscribe, context}]
+    topic = Topic.set(topic, [:callbacks], callbacks)
+    {:ok, topic}
+  end
+
+  def handle_unsubscribe(topic, context) do
+    callbacks = topic.value.callbacks ++ [{:unsubscribe, context}]
+    topic = Topic.set(topic, [:callbacks], callbacks)
+    {:ok, topic}
+  end
+
+  def handle_capture(topic, context) do
+    callbacks = topic.value.callbacks ++ [{:capture, context}]
+    topic = Topic.set(topic, [:callbacks], callbacks)
+    {:ok, topic}
+  end
+
+  def handle_execute("action", args, topic, context) do
+    callbacks = topic.value.callbacks ++ [{:execute, args, context}]
+    topic = Topic.set(topic, [:callbacks], callbacks)
+    {:ok, :executed, topic}
+  end
+
+  def handle_notify("action", args, topic, context) do
+    callbacks = topic.value.callbacks ++ [{:notify, args, context}]
+    topic = Topic.set(topic, [:callbacks], callbacks)
+    {:ok, topic}
+  end
+
+  def handle_info(msg, topic) do
+    callbacks = topic.value.callbacks ++ [{:info, msg}]
+    topic = Topic.set(topic, [:callbacks], callbacks)
+    {:ok, topic}
+  end
+end
+
+defmodule Topical.Test.FailingTopic do
+  @moduledoc """
+  Topic that fails in various ways for testing error handling.
+  Route: ["failing", :id]
+  """
+  use Topical.Topic, route: ["failing", :id]
+
+  def init(params) do
+    id = Keyword.fetch!(params, :id)
+
+    case id do
+      "init_error" ->
+        {:error, :init_failed}
+
+      _ ->
+        value = %{status: :ok}
+        {:ok, Topic.new(value)}
+    end
+  end
+
+  def handle_execute("raise", {}, _topic, _context) do
+    raise "intentional error"
+  end
+
+  def handle_execute("throw", {}, _topic, _context) do
+    throw(:intentional_throw)
+  end
+
+  def handle_execute("exit", {}, _topic, _context) do
+    exit(:intentional_exit)
+  end
+
+  def handle_execute("ok", {}, topic, _context) do
+    {:ok, :ok, topic}
+  end
+end
+
+defmodule Topical.Test.ListTopic do
+  @moduledoc """
+  Topic for testing list operations (insert/delete).
+  Route: ["lists", :id]
+  """
+  use Topical.Topic, route: ["lists", :id]
+
+  def init(_params) do
+    value = %{items: [], next_id: 1}
+    {:ok, Topic.new(value)}
+  end
+
+  def handle_execute("add", {item}, topic, _context) do
+    id = topic.value.next_id
+    topic = Topic.insert(topic, [:items], %{id: id, value: item})
+    topic = Topic.set(topic, [:next_id], id + 1)
+    {:ok, id, topic}
+  end
+
+  def handle_execute("add_at", {index, item}, topic, _context) do
+    id = topic.value.next_id
+    topic = Topic.insert(topic, [:items], index, %{id: id, value: item})
+    topic = Topic.set(topic, [:next_id], id + 1)
+    {:ok, id, topic}
+  end
+
+  def handle_execute("remove", {index}, topic, _context) do
+    topic = Topic.delete(topic, [:items], index)
+    {:ok, :ok, topic}
+  end
+
+  def handle_execute("remove_many", {index, count}, topic, _context) do
+    topic = Topic.delete(topic, [:items], index, count)
+    {:ok, :ok, topic}
+  end
+end
+
+defmodule Topical.Test.MergeTopic do
+  @moduledoc """
+  Topic for testing merge operations.
+  Route: ["merge", :id]
+  """
+  use Topical.Topic, route: ["merge", :id]
+
+  def init(_params) do
+    value = %{data: %{}}
+    {:ok, Topic.new(value)}
+  end
+
+  def handle_execute("merge", {new_data}, topic, _context) do
+    topic = Topic.merge(topic, [:data], new_data)
+    {:ok, topic.value.data, topic}
+  end
+
+  def handle_execute("set", {key, value}, topic, _context) do
+    topic = Topic.set(topic, [:data, key], value)
+    {:ok, :ok, topic}
+  end
+
+  def handle_execute("unset", {key}, topic, _context) do
+    topic = Topic.unset(topic, [:data], key)
+    {:ok, :ok, topic}
+  end
+end

--- a/server_ex/test/test_helper.exs
+++ b/server_ex/test/test_helper.exs
@@ -1,1 +1,4 @@
 ExUnit.start()
+
+# Load test support files
+Code.require_file("support/test_topics.ex", __DIR__)

--- a/server_ex/test/topical/protocol_test.exs
+++ b/server_ex/test/topical/protocol_test.exs
@@ -1,0 +1,210 @@
+defmodule Topical.ProtocolTest do
+  use ExUnit.Case
+
+  alias Topical.Protocol.{Request, Response}
+
+  describe "Request.decode/1" do
+    test "decodes notify request" do
+      json = Jason.encode!([0, ["lists", "1"], "add", ["test"]])
+
+      assert {:ok, :notify, ["lists", "1"], "add", ["test"]} = Request.decode(json)
+    end
+
+    test "decodes execute request" do
+      json = Jason.encode!([1, "ch1", ["counters", "1"], "increment", []])
+
+      assert {:ok, :execute, "ch1", ["counters", "1"], "increment", []} = Request.decode(json)
+    end
+
+    test "decodes subscribe request" do
+      json = Jason.encode!([2, "ch1", ["lists", "abc"]])
+
+      assert {:ok, :subscribe, "ch1", ["lists", "abc"]} = Request.decode(json)
+    end
+
+    test "decodes unsubscribe request" do
+      json = Jason.encode!([3, "ch1"])
+
+      assert {:ok, :unsubscribe, "ch1"} = Request.decode(json)
+    end
+
+    test "returns error for unrecognised command" do
+      json = Jason.encode!([99, "unknown"])
+
+      assert {:error, :unrecognised_command} = Request.decode(json)
+    end
+
+    test "returns error for invalid array" do
+      json = Jason.encode!([0])
+
+      assert {:error, :unrecognised_command} = Request.decode(json)
+    end
+
+    test "returns error for invalid JSON" do
+      assert {:error, :decode_failure} = Request.decode("not json")
+    end
+
+    test "returns error for non-array JSON" do
+      json = Jason.encode!(%{type: 0})
+
+      assert {:error, :unrecognised_command} = Request.decode(json)
+    end
+
+    test "decodes notify with complex args" do
+      args = %{"name" => "Test", "items" => [1, 2, 3]}
+      json = Jason.encode!([0, ["topic"], "action", args])
+
+      assert {:ok, :notify, ["topic"], "action", ^args} = Request.decode(json)
+    end
+
+    test "decodes execute with string channel_id" do
+      json = Jason.encode!([1, "channel-123", ["topic"], "action", []])
+
+      assert {:ok, :execute, "channel-123", ["topic"], "action", []} = Request.decode(json)
+    end
+
+    test "decodes execute with integer channel_id" do
+      json = Jason.encode!([1, 42, ["topic"], "action", []])
+
+      assert {:ok, :execute, 42, ["topic"], "action", []} = Request.decode(json)
+    end
+  end
+
+  describe "Response.encode_error/2" do
+    test "encodes error response" do
+      result = Response.encode_error("ch1", "not_found")
+
+      assert Jason.decode!(result) == [0, "ch1", "not_found"]
+    end
+
+    test "encodes error with complex error object" do
+      error = %{"code" => 403, "message" => "Forbidden"}
+      result = Response.encode_error("ch1", error)
+
+      assert Jason.decode!(result) == [0, "ch1", error]
+    end
+  end
+
+  describe "Response.encode_result/2" do
+    test "encodes result response" do
+      result = Response.encode_result("ch1", 42)
+
+      assert Jason.decode!(result) == [1, "ch1", 42]
+    end
+
+    test "encodes complex result" do
+      data = %{"id" => "123", "name" => "Test"}
+      result = Response.encode_result("ch1", data)
+
+      assert Jason.decode!(result) == [1, "ch1", data]
+    end
+
+    test "encodes null result" do
+      result = Response.encode_result("ch1", nil)
+
+      assert Jason.decode!(result) == [1, "ch1", nil]
+    end
+
+    test "encodes list result" do
+      result = Response.encode_result("ch1", [1, 2, 3])
+
+      assert Jason.decode!(result) == [1, "ch1", [1, 2, 3]]
+    end
+  end
+
+  describe "Response.encode_topic_reset/2" do
+    test "encodes topic reset" do
+      value = %{"count" => 0}
+      result = Response.encode_topic_reset("ch1", value)
+
+      assert Jason.decode!(result) == [2, "ch1", value]
+    end
+
+    test "encodes reset with complex value" do
+      value = %{"items" => [], "order" => [], "meta" => %{"created" => "2024-01-01"}}
+      result = Response.encode_topic_reset("ch1", value)
+
+      assert Jason.decode!(result) == [2, "ch1", value]
+    end
+  end
+
+  describe "Response.encode_topic_updates/2" do
+    test "encodes set update" do
+      updates = [{:set, [:count], 5}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", [[0, ["count"], 5]]]
+    end
+
+    test "encodes unset update" do
+      updates = [{:unset, [:data], :key}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", [[1, ["data"], "key"]]]
+    end
+
+    test "encodes insert update" do
+      updates = [{:insert, [:items], 0, ["a", "b"]}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", [[2, ["items"], 0, ["a", "b"]]]]
+    end
+
+    test "encodes insert update with nil index (append)" do
+      updates = [{:insert, [:items], nil, ["new"]}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", [[2, ["items"], nil, ["new"]]]]
+    end
+
+    test "encodes delete update" do
+      updates = [{:delete, [:items], 2, 1}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", [[3, ["items"], 2, 1]]]
+    end
+
+    test "encodes merge update" do
+      updates = [{:merge, [:data], %{a: 1}}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      decoded = Jason.decode!(result)
+      assert [3, "ch1", [[4, ["data"], %{"a" => 1}]]] = decoded
+    end
+
+    test "encodes multiple updates" do
+      updates = [
+        {:set, [:a], 1},
+        {:set, [:b], 2},
+        {:unset, [:c], :d}
+      ]
+
+      result = Response.encode_topic_updates("ch1", updates)
+      decoded = Jason.decode!(result)
+
+      assert [3, "ch1", encoded_updates] = decoded
+      assert length(encoded_updates) == 3
+    end
+
+    test "encodes empty updates list" do
+      updates = []
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", []]
+    end
+
+    test "encodes update with nested path" do
+      updates = [{:set, [:users, "123", :name], "Alice"}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", [[0, ["users", "123", "name"], "Alice"]]]
+    end
+
+    test "encodes update with integer index in path" do
+      updates = [{:set, [:items, 0, :done], true}]
+      result = Response.encode_topic_updates("ch1", updates)
+
+      assert Jason.decode!(result) == [3, "ch1", [[0, ["items", 0, "done"], true]]]
+    end
+  end
+end

--- a/server_ex/test/topical/registry_test.exs
+++ b/server_ex/test/topical/registry_test.exs
@@ -155,8 +155,7 @@ defmodule Topical.RegistryTest do
       start_supervised!(
         %{
           id: registry1,
-          start:
-            {Registry, :start_link, [[name: registry1, topics: [Topical.Test.CounterTopic]]]}
+          start: {Registry, :start_link, [[name: registry1, topics: [Topical.Test.CounterTopic]]]}
         },
         id: :reg1
       )
@@ -164,8 +163,7 @@ defmodule Topical.RegistryTest do
       start_supervised!(
         %{
           id: registry2,
-          start:
-            {Registry, :start_link, [[name: registry2, topics: [Topical.Test.CounterTopic]]]}
+          start: {Registry, :start_link, [[name: registry2, topics: [Topical.Test.CounterTopic]]]}
         },
         id: :reg2
       )

--- a/server_ex/test/topical/registry_test.exs
+++ b/server_ex/test/topical/registry_test.exs
@@ -1,0 +1,179 @@
+defmodule Topical.RegistryTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureLog
+
+  alias Topical.Registry
+
+  setup do
+    registry_name = :"test_registry_#{System.unique_integer([:positive])}"
+
+    start_supervised!(%{
+      id: registry_name,
+      start:
+        {Registry, :start_link,
+         [
+           [
+             name: registry_name,
+             topics: [
+               Topical.Test.CounterTopic,
+               Topical.Test.AuthorizedTopic,
+               Topical.Test.CallbackTopic,
+               Topical.Test.FailingTopic,
+               Topical.Test.ListTopic,
+               Topical.Test.MergeTopic
+             ]
+           ]
+         ]}
+    })
+
+    {:ok, registry: registry_name}
+  end
+
+  describe "lookup_topic/2" do
+    test "returns {:error, :not_running} for non-existent topic", %{registry: registry} do
+      assert {:error, :not_running} = Registry.lookup_topic(registry, ["counters", "nonexistent"])
+    end
+
+    test "returns {:ok, pid} for running topic", %{registry: registry} do
+      {:ok, pid} = Registry.get_topic(registry, ["counters", "1"], nil)
+      assert {:ok, ^pid} = Registry.lookup_topic(registry, ["counters", "1"])
+    end
+  end
+
+  describe "get_topic/3" do
+    test "starts topic on first access", %{registry: registry} do
+      {:ok, pid} = Registry.get_topic(registry, ["counters", "1"], nil)
+      assert is_pid(pid)
+      assert Process.alive?(pid)
+    end
+
+    test "returns same pid for same route", %{registry: registry} do
+      {:ok, pid1} = Registry.get_topic(registry, ["counters", "1"], nil)
+      {:ok, pid2} = Registry.get_topic(registry, ["counters", "1"], nil)
+      assert pid1 == pid2
+    end
+
+    test "returns different pids for different routes", %{registry: registry} do
+      {:ok, pid1} = Registry.get_topic(registry, ["counters", "1"], nil)
+      {:ok, pid2} = Registry.get_topic(registry, ["counters", "2"], nil)
+      assert pid1 != pid2
+    end
+
+    test "returns {:error, :not_found} for unknown route", %{registry: registry} do
+      assert {:error, :not_found} = Registry.get_topic(registry, ["unknown", "route"], nil)
+    end
+
+    test "returns {:error, :not_found} for partial route match", %{registry: registry} do
+      assert {:error, :not_found} = Registry.get_topic(registry, ["counters"], nil)
+    end
+
+    test "returns {:error, :not_found} for too long route", %{registry: registry} do
+      assert {:error, :not_found} = Registry.get_topic(registry, ["counters", "1", "extra"], nil)
+    end
+
+    test "passes params to topic init", %{registry: registry} do
+      {:ok, pid} = Registry.get_topic(registry, ["counters", "my-id"], nil)
+      state = :sys.get_state(pid)
+      assert state.topic.state.id == "my-id"
+    end
+  end
+
+  describe "route matching" do
+    test "matches static route parts", %{registry: registry} do
+      {:ok, _pid} = Registry.get_topic(registry, ["counters", "test"], nil)
+    end
+
+    test "captures placeholder values", %{registry: registry} do
+      {:ok, pid} = Registry.get_topic(registry, ["private", "user123"], %{user_id: "user123"})
+      state = :sys.get_state(pid)
+      assert state.topic.value.owner == "user123"
+    end
+
+    test "accepts string route format", %{registry: registry} do
+      {:ok, pid} = Registry.get_topic(registry, "counters/1", nil)
+      assert is_pid(pid)
+    end
+
+    test "accepts URI-encoded route parts", %{registry: registry} do
+      {:ok, pid} = Registry.get_topic(registry, "counters/hello%20world", nil)
+      state = :sys.get_state(pid)
+      assert state.topic.state.id == "hello world"
+    end
+  end
+
+  describe "authorization" do
+    test "allows access when authorized", %{registry: registry} do
+      context = %{user_id: "owner1"}
+      assert {:ok, _pid} = Registry.get_topic(registry, ["private", "owner1"], context)
+    end
+
+    test "denies access when unauthorized", %{registry: registry} do
+      context = %{user_id: "other"}
+      assert {:error, :forbidden} = Registry.get_topic(registry, ["private", "owner1"], context)
+    end
+
+    test "denies access when context is nil for authorized topic", %{registry: registry} do
+      assert {:error, :unauthorized} = Registry.get_topic(registry, ["private", "owner1"], nil)
+    end
+
+    test "runs authorize before starting topic", %{registry: registry} do
+      context = %{user_id: "wrong"}
+      assert {:error, :forbidden} = Registry.get_topic(registry, ["private", "owner1"], context)
+
+      # Topic should not have been started
+      assert {:error, :not_running} = Registry.lookup_topic(registry, ["private", "owner1"])
+    end
+
+    test "authorize is called on every get_topic call", %{registry: registry} do
+      # First call should succeed and start topic
+      context1 = %{user_id: "owner1"}
+      {:ok, pid} = Registry.get_topic(registry, ["private", "owner1"], context1)
+      assert Process.alive?(pid)
+
+      # Second call with wrong context should still fail
+      context2 = %{user_id: "wrong"}
+      assert {:error, :forbidden} = Registry.get_topic(registry, ["private", "owner1"], context2)
+    end
+  end
+
+  describe "topic initialization errors" do
+    test "returns error when topic init fails", %{registry: registry} do
+      # Capture the expected SASL error log from GenServer init failure
+      capture_log(fn ->
+        assert {:error, :init_failed} =
+                 Registry.get_topic(registry, ["failing", "init_error"], nil)
+      end)
+    end
+  end
+
+  describe "multiple registries" do
+    test "topics are isolated between registries" do
+      registry1 = :"registry1_#{System.unique_integer([:positive])}"
+      registry2 = :"registry2_#{System.unique_integer([:positive])}"
+
+      start_supervised!(
+        %{
+          id: registry1,
+          start:
+            {Registry, :start_link, [[name: registry1, topics: [Topical.Test.CounterTopic]]]}
+        },
+        id: :reg1
+      )
+
+      start_supervised!(
+        %{
+          id: registry2,
+          start:
+            {Registry, :start_link, [[name: registry2, topics: [Topical.Test.CounterTopic]]]}
+        },
+        id: :reg2
+      )
+
+      {:ok, pid1} = Registry.get_topic(registry1, ["counters", "1"], nil)
+      {:ok, pid2} = Registry.get_topic(registry2, ["counters", "1"], nil)
+
+      assert pid1 != pid2
+    end
+  end
+end

--- a/server_ex/test/topical/topic_test.exs
+++ b/server_ex/test/topical/topic_test.exs
@@ -1,0 +1,274 @@
+defmodule Topical.TopicTest do
+  use ExUnit.Case
+
+  alias Topical.Topic
+
+  describe "new/2" do
+    test "creates topic with value only" do
+      topic = Topic.new(%{foo: 1})
+
+      assert topic.value == %{foo: 1}
+      assert topic.state == nil
+      assert topic.updates == []
+    end
+
+    test "creates topic with value and state" do
+      topic = Topic.new(%{foo: 1}, %{bar: 2})
+
+      assert topic.value == %{foo: 1}
+      assert topic.state == %{bar: 2}
+      assert topic.updates == []
+    end
+
+    test "creates topic with nil value" do
+      topic = Topic.new(nil)
+
+      assert topic.value == nil
+      assert topic.state == nil
+    end
+
+    test "creates topic with list value" do
+      topic = Topic.new([1, 2, 3])
+
+      assert topic.value == [1, 2, 3]
+    end
+  end
+
+  describe "set/3" do
+    test "sets value at root path" do
+      topic = Topic.new(%{foo: 1})
+      topic = Topic.set(topic, [], %{bar: 2})
+
+      assert topic.value == %{bar: 2}
+      assert topic.updates == [{:set, [], %{bar: 2}}]
+    end
+
+    test "sets value at nested path" do
+      topic = Topic.new(%{foo: %{bar: 1}})
+      topic = Topic.set(topic, [:foo, :bar], 2)
+
+      assert topic.value == %{foo: %{bar: 2}}
+      assert topic.updates == [{:set, [:foo, :bar], 2}]
+    end
+
+    test "sets value at new path" do
+      topic = Topic.new(%{foo: %{}})
+      topic = Topic.set(topic, [:foo, :bar], 1)
+
+      assert topic.value == %{foo: %{bar: 1}}
+      assert topic.updates == [{:set, [:foo, :bar], 1}]
+    end
+
+    test "sets value with atom key" do
+      topic = Topic.new(%{})
+      topic = Topic.set(topic, [:foo], 1)
+
+      assert topic.value == %{foo: 1}
+    end
+
+    test "sets value within list" do
+      topic = Topic.new(%{items: [%{id: 1}, %{id: 2}]})
+      topic = Topic.set(topic, [:items, 0, :id], 10)
+
+      assert topic.value == %{items: [%{id: 10}, %{id: 2}]}
+    end
+
+    test "tracks multiple updates" do
+      topic =
+        %{a: 1, b: 2}
+        |> Topic.new()
+        |> Topic.set([:a], 10)
+        |> Topic.set([:b], 20)
+
+      assert topic.value == %{a: 10, b: 20}
+      assert topic.updates == [{:set, [:b], 20}, {:set, [:a], 10}]
+    end
+  end
+
+  describe "unset/3" do
+    test "unsets key from map" do
+      topic = Topic.new(%{foo: %{bar: 1, baz: 2}})
+      topic = Topic.unset(topic, [:foo], :bar)
+
+      assert topic.value == %{foo: %{baz: 2}}
+      assert topic.updates == [{:unset, [:foo], :bar}]
+    end
+
+    test "unsets key from nested map" do
+      topic = Topic.new(%{foo: %{bar: %{a: 1, b: 2}}})
+      topic = Topic.unset(topic, [:foo, :bar], :a)
+
+      assert topic.value == %{foo: %{bar: %{b: 2}}}
+    end
+
+    test "unsets key from root" do
+      topic = Topic.new(%{foo: 1, bar: 2})
+      topic = Topic.unset(topic, [], :foo)
+
+      assert topic.value == %{bar: 2}
+    end
+  end
+
+  describe "insert/4" do
+    test "inserts single value at end of list" do
+      topic = Topic.new(%{items: [1, 2]})
+      topic = Topic.insert(topic, [:items], 3)
+
+      assert topic.value == %{items: [1, 2, 3]}
+      assert topic.updates == [{:insert, [:items], nil, [3]}]
+    end
+
+    test "inserts single value at specific index" do
+      topic = Topic.new(%{items: [1, 3]})
+      topic = Topic.insert(topic, [:items], 1, 2)
+
+      assert topic.value == %{items: [1, 2, 3]}
+      assert topic.updates == [{:insert, [:items], 1, [2]}]
+    end
+
+    test "inserts multiple values at end" do
+      topic = Topic.new(%{items: [1]})
+      topic = Topic.insert(topic, [:items], [2, 3])
+
+      assert topic.value == %{items: [1, 2, 3]}
+      assert topic.updates == [{:insert, [:items], nil, [2, 3]}]
+    end
+
+    test "inserts multiple values at specific index" do
+      topic = Topic.new(%{items: [1, 4]})
+      topic = Topic.insert(topic, [:items], 1, [2, 3])
+
+      assert topic.value == %{items: [1, 2, 3, 4]}
+      assert topic.updates == [{:insert, [:items], 1, [2, 3]}]
+    end
+
+    test "inserts at beginning with index 0" do
+      topic = Topic.new(%{items: [2, 3]})
+      topic = Topic.insert(topic, [:items], 0, 1)
+
+      assert topic.value == %{items: [1, 2, 3]}
+    end
+
+    test "does not add update for empty list" do
+      topic = Topic.new(%{items: [1, 2]})
+      topic = Topic.insert(topic, [:items], [])
+
+      assert topic.value == %{items: [1, 2]}
+      assert topic.updates == []
+    end
+
+    test "inserts into nested list" do
+      topic = Topic.new(%{foo: %{bar: [1, 2]}})
+      topic = Topic.insert(topic, [:foo, :bar], 3)
+
+      assert topic.value == %{foo: %{bar: [1, 2, 3]}}
+    end
+  end
+
+  describe "delete/4" do
+    test "deletes single element from list" do
+      topic = Topic.new(%{items: [1, 2, 3]})
+      topic = Topic.delete(topic, [:items], 1)
+
+      assert topic.value == %{items: [1, 3]}
+      assert topic.updates == [{:delete, [:items], 1, 1}]
+    end
+
+    test "deletes multiple elements from list" do
+      topic = Topic.new(%{items: [1, 2, 3, 4]})
+      topic = Topic.delete(topic, [:items], 1, 2)
+
+      assert topic.value == %{items: [1, 4]}
+      assert topic.updates == [{:delete, [:items], 1, 2}]
+    end
+
+    test "deletes from beginning of list" do
+      topic = Topic.new(%{items: [1, 2, 3]})
+      topic = Topic.delete(topic, [:items], 0)
+
+      assert topic.value == %{items: [2, 3]}
+    end
+
+    test "deletes from end of list" do
+      topic = Topic.new(%{items: [1, 2, 3]})
+      topic = Topic.delete(topic, [:items], 2)
+
+      assert topic.value == %{items: [1, 2]}
+    end
+
+    test "deletes from nested list" do
+      topic = Topic.new(%{foo: %{bar: [1, 2, 3]}})
+      topic = Topic.delete(topic, [:foo, :bar], 0)
+
+      assert topic.value == %{foo: %{bar: [2, 3]}}
+    end
+  end
+
+  describe "merge/3" do
+    test "merges map into existing map" do
+      topic = Topic.new(%{data: %{a: 1, b: 2}})
+      topic = Topic.merge(topic, [:data], %{b: 3, c: 4})
+
+      assert topic.value == %{data: %{a: 1, b: 3, c: 4}}
+      assert topic.updates == [{:merge, [:data], %{b: 3, c: 4}}]
+    end
+
+    test "merges into empty map" do
+      topic = Topic.new(%{data: %{}})
+      topic = Topic.merge(topic, [:data], %{a: 1})
+
+      assert topic.value == %{data: %{a: 1}}
+    end
+
+    test "merges into nil (creates map)" do
+      topic = Topic.new(%{data: nil})
+      topic = Topic.merge(topic, [:data], %{a: 1})
+
+      assert topic.value == %{data: %{a: 1}}
+    end
+
+    test "merges at root" do
+      topic = Topic.new(%{a: 1, b: 2})
+      topic = Topic.merge(topic, [], %{b: 3, c: 4})
+
+      assert topic.value == %{a: 1, b: 3, c: 4}
+    end
+
+    test "merges at nested path" do
+      topic = Topic.new(%{foo: %{bar: %{a: 1}}})
+      topic = Topic.merge(topic, [:foo, :bar], %{b: 2})
+
+      assert topic.value == %{foo: %{bar: %{a: 1, b: 2}}}
+    end
+  end
+
+  describe "chained operations" do
+    test "supports chaining multiple different operations" do
+      topic =
+        %{users: %{}, order: []}
+        |> Topic.new()
+        |> Topic.set([:users, "1"], %{name: "Alice"})
+        |> Topic.insert([:order], "1")
+        |> Topic.set([:users, "2"], %{name: "Bob"})
+        |> Topic.insert([:order], "2")
+        |> Topic.merge([:users, "1"], %{age: 30})
+
+      assert topic.value == %{
+               users: %{"1" => %{name: "Alice", age: 30}, "2" => %{name: "Bob"}},
+               order: ["1", "2"]
+             }
+
+      # Updates are in reverse order
+      assert length(topic.updates) == 5
+    end
+
+    test "state is preserved through operations" do
+      topic = Topic.new(%{count: 0}, %{id: "test"})
+      topic = Topic.set(topic, [:count], 1)
+      topic = Topic.set(topic, [:count], 2)
+
+      assert topic.state == %{id: "test"}
+      assert topic.value.count == 2
+    end
+  end
+end


### PR DESCRIPTION
This adds support for an `authorize` callback, which will be passed the route parameters and the connection's callback, and can be used to determine whether the connection is authorised to access the topic (including subscribing, executing, notifying or capturing). The idea is that the connection is authenticated at the point it connects (by the adapter), and then authorisation happens on a per-topic basis with the `authorize` callback.

Also adds tests, and sets up a CI workflow.