### PR TITLE
Add server support for topic parameters

### DIFF
--- a/.github/workflows/server_ex.yml
+++ b/.github/workflows/server_ex.yml
@@ -1,11 +1,17 @@
-name: CI
+name: Server (Elixir)
 
 on:
   push:
     branches: [main]
-    tags: ["v*"]
+    tags: ["server_ex/v*"]
+    paths:
+      - "server_ex/**"
+      - ".github/workflows/server_ex.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "server_ex/**"
+      - ".github/workflows/server_ex.yml"
 
 jobs:
   test:
@@ -22,8 +28,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.16"
-          otp-version: "26"
+          elixir-version: "1.18"
+          otp-version: "27"
 
       - name: Restore dependencies cache
         uses: actions/cache@v4
@@ -52,7 +58,7 @@ jobs:
   release:
     name: Release to Hex
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/server_ex/v')
     runs-on: ubuntu-latest
 
     defaults:
@@ -82,7 +88,7 @@ jobs:
 
       - name: Verify tag matches mix.exs version
         run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          TAG_VERSION="${GITHUB_REF#refs/tags/server_ex/v}"
           MIX_VERSION=$(grep 'version:' mix.exs | sed 's/.*version: "\(.*\)".*/\1/')
           echo "Tag version: $TAG_VERSION"
           echo "mix.exs version: $MIX_VERSION"

--- a/server_ex/CHANGELOG.md
+++ b/server_ex/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 0.3.0
+
+### Featuyres
+
+- Adds support for topics to have optional parameters (with defaults; in addition to required route parameters).
+
+### Improvements
+
+- Updates `subscribe`/`unsubscribe` to avoid unnecessarily initialising topic to unsubscribe.
+
 ## 0.2.4
 
 ### Features

--- a/server_ex/docs/getting-started.md
+++ b/server_ex/docs/getting-started.md
@@ -80,6 +80,36 @@ end
 Return `:ok` to allow access, or `{:error, reason}` to deny. The default implementation
 allows all access.
 
+## Parameters
+
+Topics can declare optional parameters with default values. Different parameter values create
+separate topic instances:
+
+```elixir
+defmodule MyApp.Topics.Leaderboard do
+  use Topical.Topic, route: ["leaderboards", :game_id], params: [region: "global"]
+
+  def init(params) do
+    game_id = Keyword.fetch!(params, :game_id)
+    region = Keyword.fetch!(params, :region)
+
+    {:ok, Topic.new(%{game_id: game_id, region: region, entries: []})}
+  end
+end
+```
+
+Clients subscribe with params to access specific instances:
+
+```elixir
+# Uses default region "global"
+Topical.subscribe(MyApp.Topical, ["leaderboards", "chess"], self())
+
+# Subscribes to EU region (separate instance)
+Topical.subscribe(MyApp.Topical, ["leaderboards", "chess"], self(), nil, %{"region" => "eu"})
+```
+
+Parameters are also available in `authorize/2` for access control based on param values.
+
 ## Supervision
 
 Then add a Topical registry to your application supervision tree, referencing the topic:

--- a/server_ex/docs/introduction.md
+++ b/server_ex/docs/introduction.md
@@ -4,9 +4,10 @@ Topical is a library for defining and serving _topics_. A topic is a value that 
 observed in real-time by connected clients. The server-side implementation takes care of defining
 how to intialise the state, and then how to keep it updated.
 
-Multiple clients can subscribe to an instance of a topic - instances are identifier by a path,
+Multiple clients can subscribe to an instance of a topic - instances are identified by a path,
 which matches the route defined by a topic. Multiple instances of a topic can exist by using route
-placeholders.
+placeholders. Topics can also declare optional parameters; different parameter values create
+separate instances sharing the same route.
 
 Topical takes care of starting topic instances as needed, and stopping them once all clients have
 disconnected.

--- a/server_ex/lib/topical/protocol.ex
+++ b/server_ex/lib/topical/protocol.ex
@@ -6,15 +6,28 @@ defmodule Topical.Protocol do
 
     def decode(text) do
       case Jason.decode(text) do
+        # Notify: [0, topic, action, args] or [0, topic, action, args, params]
         {:ok, [0, topic, action, args]} ->
-          {:ok, :notify, topic, action, args}
+          {:ok, :notify, topic, action, args, %{}}
 
+        {:ok, [0, topic, action, args, params]} when is_map(params) ->
+          {:ok, :notify, topic, action, args, params}
+
+        # Execute: [1, channel_id, topic, action, args] or [1, channel_id, topic, action, args, params]
         {:ok, [1, channel_id, topic, action, args]} ->
-          {:ok, :execute, channel_id, topic, action, args}
+          {:ok, :execute, channel_id, topic, action, args, %{}}
 
+        {:ok, [1, channel_id, topic, action, args, params]} when is_map(params) ->
+          {:ok, :execute, channel_id, topic, action, args, params}
+
+        # Subscribe: [2, channel_id, topic] or [2, channel_id, topic, params]
         {:ok, [2, channel_id, topic]} ->
-          {:ok, :subscribe, channel_id, topic}
+          {:ok, :subscribe, channel_id, topic, %{}}
 
+        {:ok, [2, channel_id, topic, params]} when is_map(params) ->
+          {:ok, :subscribe, channel_id, topic, params}
+
+        # Unsubscribe: [3, channel_id]
         {:ok, [3, channel_id]} ->
           {:ok, :unsubscribe, channel_id}
 
@@ -44,6 +57,10 @@ defmodule Topical.Protocol do
 
     def encode_topic_updates(channel_id, updates) do
       Jason.encode!([3, channel_id, Enum.map(updates, &encode_update/1)])
+    end
+
+    def encode_topic_alias(channel_id, existing_channel_id) do
+      Jason.encode!([4, channel_id, existing_channel_id])
     end
 
     defp encode_update(update) do

--- a/server_ex/lib/topical/topic/server.ex
+++ b/server_ex/lib/topical/topic/server.ex
@@ -10,7 +10,8 @@ defmodule Topical.Topic.Server do
   @doc """
   Invoked to check whether a client is authorized to access this topic.
 
-  `params` are the values associated with the placeholders in the route.
+  `params` are the values associated with the placeholders in the route,
+  merged with the request params (with defaults applied).
   `context` is the context established during the WebSocket connection.
 
   Return `:ok` to allow access, or `{:error, reason}` to deny.
@@ -22,9 +23,10 @@ defmodule Topical.Topic.Server do
   @doc """
   Invoked when the topic is started to get the initial state.
 
-  `params` are the values associated with the placeholders in the route.
+  `params` are the values associated with the placeholders in the route,
+  merged with the request params (with defaults applied).
   """
-  @callback init(params :: [...]) :: {:ok, %Topic{}} | {:error, reason :: any}
+  @callback init(params :: keyword()) :: {:ok, %Topic{}} | {:error, reason :: any}
 
   @doc """
   Invoked before a client subscribes (but after initialisation).

--- a/server_ex/mix.exs
+++ b/server_ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Topical.MixProject do
   def project do
     [
       app: :topical,
-      version: "0.2.4",
+      version: "0.3.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/server_ex/test/integration_test.exs
+++ b/server_ex/test/integration_test.exs
@@ -17,7 +17,9 @@ defmodule Topical.IntegrationTest do
                Topical.Test.CallbackTopic,
                Topical.Test.FailingTopic,
                Topical.Test.ListTopic,
-               Topical.Test.MergeTopic
+               Topical.Test.MergeTopic,
+               Topical.Test.LeaderboardTopic,
+               Topical.Test.DocumentTopic
              ]
            ]
          ]}
@@ -28,14 +30,14 @@ defmodule Topical.IntegrationTest do
 
   describe "subscribe/4" do
     test "subscriber receives reset message", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["counters", "1"], self())
 
       assert_receive {:reset, ^ref, %{count: 0}}
     end
 
     test "returns ref that matches messages", %{registry: registry} do
-      {:ok, ref1} = Topical.subscribe(registry, ["counters", "1"], self())
-      {:ok, ref2} = Topical.subscribe(registry, ["counters", "2"], self())
+      {:ok, ref1, _server1} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref2, _server2} = Topical.subscribe(registry, ["counters", "2"], self())
 
       assert ref1 != ref2
 
@@ -44,7 +46,7 @@ defmodule Topical.IntegrationTest do
     end
 
     test "subscriber receives updates after subscribe", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["counters", "1"], self())
       assert_receive {:reset, ^ref, %{count: 0}}
 
       Topical.execute(registry, ["counters", "1"], "increment", {})
@@ -53,23 +55,16 @@ defmodule Topical.IntegrationTest do
     end
   end
 
-  describe "unsubscribe/3" do
+  describe "unsubscribe/2" do
     test "stops receiving updates after unsubscribe", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref, server} = Topical.subscribe(registry, ["counters", "1"], self())
       assert_receive {:reset, ^ref, %{count: 0}}
 
-      :ok = Topical.unsubscribe(registry, ["counters", "1"], ref)
+      Topical.unsubscribe(server, ref)
 
       Topical.execute(registry, ["counters", "1"], "increment", {})
 
       refute_receive {:updates, _, _}, 100
-    end
-
-    test "returns error for non-running topic", %{registry: registry} do
-      ref = make_ref()
-
-      assert {:error, :not_running} =
-               Topical.unsubscribe(registry, ["counters", "nonexistent"], ref)
     end
   end
 
@@ -83,7 +78,7 @@ defmodule Topical.IntegrationTest do
     end
 
     test "subscribers receive updates from execute", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["counters", "1"], self())
       assert_receive {:reset, ^ref, %{count: 0}}
 
       {:ok, _} = Topical.execute(registry, ["counters", "1"], "set", {42})
@@ -99,7 +94,7 @@ defmodule Topical.IntegrationTest do
 
   describe "notify/5" do
     test "sends notification to topic", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["counters", "1"], self())
       assert_receive {:reset, ^ref, %{count: 0}}
 
       :ok = Topical.notify(registry, ["counters", "1"], "increment", {})
@@ -140,8 +135,8 @@ defmodule Topical.IntegrationTest do
 
   describe "multiple subscribers" do
     test "all subscribers receive same updates", %{registry: registry} do
-      {:ok, ref1} = Topical.subscribe(registry, ["counters", "1"], self())
-      {:ok, ref2} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref1, _server1} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref2, _server2} = Topical.subscribe(registry, ["counters", "1"], self())
 
       assert_receive {:reset, ^ref1, %{count: 0}}
       assert_receive {:reset, ^ref2, %{count: 0}}
@@ -153,13 +148,13 @@ defmodule Topical.IntegrationTest do
     end
 
     test "unsubscribing one does not affect others", %{registry: registry} do
-      {:ok, ref1} = Topical.subscribe(registry, ["counters", "1"], self())
-      {:ok, ref2} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref1, server} = Topical.subscribe(registry, ["counters", "1"], self())
+      {:ok, ref2, _server2} = Topical.subscribe(registry, ["counters", "1"], self())
 
       assert_receive {:reset, ^ref1, _}
       assert_receive {:reset, ^ref2, _}
 
-      Topical.unsubscribe(registry, ["counters", "1"], ref1)
+      Topical.unsubscribe(server, ref1)
       Topical.execute(registry, ["counters", "1"], "increment", {})
 
       # ref1 should not receive update
@@ -174,7 +169,7 @@ defmodule Topical.IntegrationTest do
       assert {:error, :forbidden} =
                Topical.subscribe(registry, ["private", "owner1"], self(), %{user_id: "other"})
 
-      {:ok, _ref} =
+      {:ok, _ref, _server} =
         Topical.subscribe(registry, ["private", "owner1"], self(), %{user_id: "owner1"})
     end
 
@@ -223,7 +218,7 @@ defmodule Topical.IntegrationTest do
   describe "callback invocations" do
     test "handle_subscribe is called on subscribe", %{registry: registry} do
       context = %{user: "test"}
-      {:ok, ref} = Topical.subscribe(registry, ["callbacks", "1"], self(), context)
+      {:ok, ref, _server} = Topical.subscribe(registry, ["callbacks", "1"], self(), context)
 
       assert_receive {:reset, ^ref, %{callbacks: callbacks}}
       assert [{:subscribe, ^context}] = callbacks
@@ -231,10 +226,10 @@ defmodule Topical.IntegrationTest do
 
     test "handle_unsubscribe is called on unsubscribe", %{registry: registry} do
       context = %{user: "test"}
-      {:ok, ref} = Topical.subscribe(registry, ["callbacks", "1"], self(), context)
+      {:ok, ref, server} = Topical.subscribe(registry, ["callbacks", "1"], self(), context)
       assert_receive {:reset, ^ref, _}
 
-      Topical.unsubscribe(registry, ["callbacks", "1"], ref)
+      Topical.unsubscribe(server, ref)
 
       # Give time for unsubscribe to process
       Process.sleep(50)
@@ -284,32 +279,32 @@ defmodule Topical.IntegrationTest do
 
   describe "topic timeout" do
     test "topic stops after timeout with no subscribers", %{registry: registry} do
-      # Start a topic
-      {:ok, _} = Topical.execute(registry, ["counters", "timeout-test"], "increment", {})
+      # Start a topic and get the server PID
+      {:ok, sub_ref, server} = Topical.subscribe(registry, ["counters", "timeout-test"], self())
+      assert_receive {:reset, _, _}
+      assert Process.alive?(server)
 
-      {:ok, pid} = Topical.Registry.lookup_topic(registry, ["counters", "timeout-test"])
-      assert Process.alive?(pid)
+      # Unsubscribe so there are no subscribers
+      Topical.unsubscribe(server, sub_ref)
 
-      # Wait for timeout (10 seconds is default, but we'll just check the behavior)
       # We use a reference to monitor the process
-      ref = Process.monitor(pid)
+      ref = Process.monitor(server)
 
-      # Topic should still be running after short delay
-      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 100
+      # Topic should still be running after short delay (timeout is 10 seconds)
+      refute_receive {:DOWN, ^ref, :process, ^server, _}, 100
 
       # Clean up
       Process.demonitor(ref, [:flush])
     end
 
     test "topic does not timeout while subscribed", %{registry: registry} do
-      {:ok, sub_ref} = Topical.subscribe(registry, ["counters", "sub-test"], self())
-      assert_receive {:reset, ^sub_ref, _}
+      {:ok, _sub_ref, server} = Topical.subscribe(registry, ["counters", "sub-test"], self())
+      assert_receive {:reset, _, _}
 
-      {:ok, pid} = Topical.Registry.lookup_topic(registry, ["counters", "sub-test"])
-      mon_ref = Process.monitor(pid)
+      mon_ref = Process.monitor(server)
 
       # Should not timeout while subscribed
-      refute_receive {:DOWN, ^mon_ref, :process, ^pid, _}, 200
+      refute_receive {:DOWN, ^mon_ref, :process, ^server, _}, 200
 
       Process.demonitor(mon_ref, [:flush])
     end
@@ -317,7 +312,7 @@ defmodule Topical.IntegrationTest do
 
   describe "list operations" do
     test "insert operations broadcast to subscribers", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["lists", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["lists", "1"], self())
       assert_receive {:reset, ^ref, %{items: [], next_id: 1}}
 
       {:ok, 1} = Topical.execute(registry, ["lists", "1"], "add", {"first"})
@@ -327,7 +322,7 @@ defmodule Topical.IntegrationTest do
     end
 
     test "delete operations broadcast to subscribers", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["lists", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["lists", "1"], self())
       assert_receive {:reset, ^ref, _}
 
       {:ok, _} = Topical.execute(registry, ["lists", "1"], "add", {"first"})
@@ -344,7 +339,7 @@ defmodule Topical.IntegrationTest do
 
   describe "merge operations" do
     test "merge operations broadcast to subscribers", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["merge", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["merge", "1"], self())
       assert_receive {:reset, ^ref, %{data: %{}}}
 
       {:ok, _} = Topical.execute(registry, ["merge", "1"], "merge", {%{a: 1, b: 2}})
@@ -353,7 +348,7 @@ defmodule Topical.IntegrationTest do
     end
 
     test "unset operations broadcast to subscribers", %{registry: registry} do
-      {:ok, ref} = Topical.subscribe(registry, ["merge", "1"], self())
+      {:ok, ref, _server} = Topical.subscribe(registry, ["merge", "1"], self())
       assert_receive {:reset, ^ref, _}
 
       {:ok, _} = Topical.execute(registry, ["merge", "1"], "set", {:key, "value"})
@@ -372,7 +367,7 @@ defmodule Topical.IntegrationTest do
 
       subscriber =
         spawn(fn ->
-          {:ok, _ref} = Topical.subscribe(registry, ["callbacks", "death-test"], self())
+          {:ok, _ref, _server} = Topical.subscribe(registry, ["callbacks", "death-test"], self())
           send(test_pid, :subscribed)
 
           receive do

--- a/server_ex/test/topical/protocol_test.exs
+++ b/server_ex/test/topical/protocol_test.exs
@@ -7,19 +7,40 @@ defmodule Topical.ProtocolTest do
     test "decodes notify request" do
       json = Jason.encode!([0, ["lists", "1"], "add", ["test"]])
 
-      assert {:ok, :notify, ["lists", "1"], "add", ["test"]} = Request.decode(json)
+      assert {:ok, :notify, ["lists", "1"], "add", ["test"], %{}} = Request.decode(json)
+    end
+
+    test "decodes notify request with params" do
+      json = Jason.encode!([0, ["lists", "1"], "add", ["test"], %{"layer" => "bg"}])
+
+      assert {:ok, :notify, ["lists", "1"], "add", ["test"], %{"layer" => "bg"}} =
+               Request.decode(json)
     end
 
     test "decodes execute request" do
       json = Jason.encode!([1, "ch1", ["counters", "1"], "increment", []])
 
-      assert {:ok, :execute, "ch1", ["counters", "1"], "increment", []} = Request.decode(json)
+      assert {:ok, :execute, "ch1", ["counters", "1"], "increment", [], %{}} =
+               Request.decode(json)
+    end
+
+    test "decodes execute request with params" do
+      json = Jason.encode!([1, "ch1", ["counters", "1"], "increment", [], %{"ns" => "test"}])
+
+      assert {:ok, :execute, "ch1", ["counters", "1"], "increment", [], %{"ns" => "test"}} =
+               Request.decode(json)
     end
 
     test "decodes subscribe request" do
       json = Jason.encode!([2, "ch1", ["lists", "abc"]])
 
-      assert {:ok, :subscribe, "ch1", ["lists", "abc"]} = Request.decode(json)
+      assert {:ok, :subscribe, "ch1", ["lists", "abc"], %{}} = Request.decode(json)
+    end
+
+    test "decodes subscribe request with params" do
+      json = Jason.encode!([2, "ch1", ["lists", "abc"], %{"layer" => "fg"}])
+
+      assert {:ok, :subscribe, "ch1", ["lists", "abc"], %{"layer" => "fg"}} = Request.decode(json)
     end
 
     test "decodes unsubscribe request" do
@@ -54,19 +75,19 @@ defmodule Topical.ProtocolTest do
       args = %{"name" => "Test", "items" => [1, 2, 3]}
       json = Jason.encode!([0, ["topic"], "action", args])
 
-      assert {:ok, :notify, ["topic"], "action", ^args} = Request.decode(json)
+      assert {:ok, :notify, ["topic"], "action", ^args, %{}} = Request.decode(json)
     end
 
     test "decodes execute with string channel_id" do
       json = Jason.encode!([1, "channel-123", ["topic"], "action", []])
 
-      assert {:ok, :execute, "channel-123", ["topic"], "action", []} = Request.decode(json)
+      assert {:ok, :execute, "channel-123", ["topic"], "action", [], %{}} = Request.decode(json)
     end
 
     test "decodes execute with integer channel_id" do
       json = Jason.encode!([1, 42, ["topic"], "action", []])
 
-      assert {:ok, :execute, 42, ["topic"], "action", []} = Request.decode(json)
+      assert {:ok, :execute, 42, ["topic"], "action", [], %{}} = Request.decode(json)
     end
   end
 

--- a/server_ex/test/topical/registry_test.exs
+++ b/server_ex/test/topical/registry_test.exs
@@ -5,6 +5,13 @@ defmodule Topical.RegistryTest do
 
   alias Topical.Registry
 
+  # Helper to resolve and get topic in one call (for test convenience)
+  defp resolve_and_get_topic(registry, route, context, params \\ %{}) do
+    with {:ok, module, all_params, topic_key} <- Registry.resolve_topic(registry, route, params) do
+      Registry.get_topic(registry, module, all_params, topic_key, context)
+    end
+  end
+
   setup do
     registry_name = :"test_registry_#{System.unique_integer([:positive])}"
 
@@ -21,7 +28,9 @@ defmodule Topical.RegistryTest do
                Topical.Test.CallbackTopic,
                Topical.Test.FailingTopic,
                Topical.Test.ListTopic,
-               Topical.Test.MergeTopic
+               Topical.Test.MergeTopic,
+               Topical.Test.LeaderboardTopic,
+               Topical.Test.DocumentTopic
              ]
            ]
          ]}
@@ -30,50 +39,39 @@ defmodule Topical.RegistryTest do
     {:ok, registry: registry_name}
   end
 
-  describe "lookup_topic/2" do
-    test "returns {:error, :not_running} for non-existent topic", %{registry: registry} do
-      assert {:error, :not_running} = Registry.lookup_topic(registry, ["counters", "nonexistent"])
-    end
-
-    test "returns {:ok, pid} for running topic", %{registry: registry} do
-      {:ok, pid} = Registry.get_topic(registry, ["counters", "1"], nil)
-      assert {:ok, ^pid} = Registry.lookup_topic(registry, ["counters", "1"])
-    end
-  end
-
-  describe "get_topic/3" do
+  describe "resolve_topic and get_topic" do
     test "starts topic on first access", %{registry: registry} do
-      {:ok, pid} = Registry.get_topic(registry, ["counters", "1"], nil)
+      {:ok, pid} = resolve_and_get_topic(registry, ["counters", "1"], nil)
       assert is_pid(pid)
       assert Process.alive?(pid)
     end
 
     test "returns same pid for same route", %{registry: registry} do
-      {:ok, pid1} = Registry.get_topic(registry, ["counters", "1"], nil)
-      {:ok, pid2} = Registry.get_topic(registry, ["counters", "1"], nil)
+      {:ok, pid1} = resolve_and_get_topic(registry, ["counters", "1"], nil)
+      {:ok, pid2} = resolve_and_get_topic(registry, ["counters", "1"], nil)
       assert pid1 == pid2
     end
 
     test "returns different pids for different routes", %{registry: registry} do
-      {:ok, pid1} = Registry.get_topic(registry, ["counters", "1"], nil)
-      {:ok, pid2} = Registry.get_topic(registry, ["counters", "2"], nil)
+      {:ok, pid1} = resolve_and_get_topic(registry, ["counters", "1"], nil)
+      {:ok, pid2} = resolve_and_get_topic(registry, ["counters", "2"], nil)
       assert pid1 != pid2
     end
 
     test "returns {:error, :not_found} for unknown route", %{registry: registry} do
-      assert {:error, :not_found} = Registry.get_topic(registry, ["unknown", "route"], nil)
+      assert {:error, :not_found} = Registry.resolve_topic(registry, ["unknown", "route"])
     end
 
     test "returns {:error, :not_found} for partial route match", %{registry: registry} do
-      assert {:error, :not_found} = Registry.get_topic(registry, ["counters"], nil)
+      assert {:error, :not_found} = Registry.resolve_topic(registry, ["counters"])
     end
 
     test "returns {:error, :not_found} for too long route", %{registry: registry} do
-      assert {:error, :not_found} = Registry.get_topic(registry, ["counters", "1", "extra"], nil)
+      assert {:error, :not_found} = Registry.resolve_topic(registry, ["counters", "1", "extra"])
     end
 
     test "passes params to topic init", %{registry: registry} do
-      {:ok, pid} = Registry.get_topic(registry, ["counters", "my-id"], nil)
+      {:ok, pid} = resolve_and_get_topic(registry, ["counters", "my-id"], nil)
       state = :sys.get_state(pid)
       assert state.topic.state.id == "my-id"
     end
@@ -81,22 +79,22 @@ defmodule Topical.RegistryTest do
 
   describe "route matching" do
     test "matches static route parts", %{registry: registry} do
-      {:ok, _pid} = Registry.get_topic(registry, ["counters", "test"], nil)
+      {:ok, _pid} = resolve_and_get_topic(registry, ["counters", "test"], nil)
     end
 
     test "captures placeholder values", %{registry: registry} do
-      {:ok, pid} = Registry.get_topic(registry, ["private", "user123"], %{user_id: "user123"})
+      {:ok, pid} = resolve_and_get_topic(registry, ["private", "user123"], %{user_id: "user123"})
       state = :sys.get_state(pid)
       assert state.topic.value.owner == "user123"
     end
 
     test "accepts string route format", %{registry: registry} do
-      {:ok, pid} = Registry.get_topic(registry, "counters/1", nil)
+      {:ok, pid} = resolve_and_get_topic(registry, "counters/1", nil)
       assert is_pid(pid)
     end
 
     test "accepts URI-encoded route parts", %{registry: registry} do
-      {:ok, pid} = Registry.get_topic(registry, "counters/hello%20world", nil)
+      {:ok, pid} = resolve_and_get_topic(registry, "counters/hello%20world", nil)
       state = :sys.get_state(pid)
       assert state.topic.state.id == "hello world"
     end
@@ -105,35 +103,44 @@ defmodule Topical.RegistryTest do
   describe "authorization" do
     test "allows access when authorized", %{registry: registry} do
       context = %{user_id: "owner1"}
-      assert {:ok, _pid} = Registry.get_topic(registry, ["private", "owner1"], context)
+      assert {:ok, _pid} = resolve_and_get_topic(registry, ["private", "owner1"], context)
     end
 
     test "denies access when unauthorized", %{registry: registry} do
       context = %{user_id: "other"}
-      assert {:error, :forbidden} = Registry.get_topic(registry, ["private", "owner1"], context)
+
+      assert {:error, :forbidden} =
+               resolve_and_get_topic(registry, ["private", "owner1"], context)
     end
 
     test "denies access when context is nil for authorized topic", %{registry: registry} do
-      assert {:error, :unauthorized} = Registry.get_topic(registry, ["private", "owner1"], nil)
+      assert {:error, :unauthorized} = resolve_and_get_topic(registry, ["private", "owner1"], nil)
     end
 
     test "runs authorize before starting topic", %{registry: registry} do
       context = %{user_id: "wrong"}
-      assert {:error, :forbidden} = Registry.get_topic(registry, ["private", "owner1"], context)
 
-      # Topic should not have been started
-      assert {:error, :not_running} = Registry.lookup_topic(registry, ["private", "owner1"])
+      assert {:error, :forbidden} =
+               resolve_and_get_topic(registry, ["private", "owner1"], context)
+
+      # Topic should not have been started - trying to get it again with correct
+      # context should start a new topic (proving it wasn't started before)
+      context2 = %{user_id: "owner1"}
+      {:ok, pid} = resolve_and_get_topic(registry, ["private", "owner1"], context2)
+      assert Process.alive?(pid)
     end
 
     test "authorize is called on every get_topic call", %{registry: registry} do
       # First call should succeed and start topic
       context1 = %{user_id: "owner1"}
-      {:ok, pid} = Registry.get_topic(registry, ["private", "owner1"], context1)
+      {:ok, pid} = resolve_and_get_topic(registry, ["private", "owner1"], context1)
       assert Process.alive?(pid)
 
       # Second call with wrong context should still fail
       context2 = %{user_id: "wrong"}
-      assert {:error, :forbidden} = Registry.get_topic(registry, ["private", "owner1"], context2)
+
+      assert {:error, :forbidden} =
+               resolve_and_get_topic(registry, ["private", "owner1"], context2)
     end
   end
 
@@ -142,7 +149,7 @@ defmodule Topical.RegistryTest do
       # Capture the expected SASL error log from GenServer init failure
       capture_log(fn ->
         assert {:error, :init_failed} =
-                 Registry.get_topic(registry, ["failing", "init_error"], nil)
+                 resolve_and_get_topic(registry, ["failing", "init_error"], nil)
       end)
     end
   end
@@ -168,8 +175,8 @@ defmodule Topical.RegistryTest do
         id: :reg2
       )
 
-      {:ok, pid1} = Registry.get_topic(registry1, ["counters", "1"], nil)
-      {:ok, pid2} = Registry.get_topic(registry2, ["counters", "1"], nil)
+      {:ok, pid1} = resolve_and_get_topic(registry1, ["counters", "1"], nil)
+      {:ok, pid2} = resolve_and_get_topic(registry2, ["counters", "1"], nil)
 
       assert pid1 != pid2
     end


### PR DESCRIPTION
This updates the server to support optional topic parameters, in addition to the (required) route parameters.

Parameter values must be strings, which means we can support passing them unambiguously as query string parameters for the REST-style adapter.

The use of defaults means that the protocol is extended to support an 'alias' response, handling the case where a client separately subscribes implicitly and explicitly with a default value. Though the protocol remains backwards compatible (supporting messages that don't include parameters).

This change also updates the signature of the `Topical.subscribe` and `Topical.unsubscribe` functions so that the `subscribe` result includes the PID of the server, avoiding the need to resolve this during the unsubscribe (and potentially initialising a topic unnecessarily).