### PR TITLE
Update Actions Node version

### DIFF
--- a/.github/workflows/client_js.yml
+++ b/.github/workflows/client_js.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: client_js/package-lock.json
 
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
           cache-dependency-path: client_js/package-lock.json


### PR DESCRIPTION
This updates the Node version used in the Actions workflow. I think using the older version might be causing the release to fail, since we're trying to rely on OIDC, which requires 11.5.1 or later of the npm CLI.