### PR TITLE
Fix React client version

### DIFF
--- a/client_react/CHANGELOG.md
+++ b/client_react/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.3.2
+## 0.3.3
 
 ### Features
 

--- a/client_react/package.json
+++ b/client_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topical/react",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "React Topical client.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
This fixes the version of the React client. It looks like the previous version was published without updating the version in the repo. (This shouldn't happen again, now that publishing is happening from the Actions workflow.)