### PR TITLE
Replace 'authorize' with 'connect' callback

### DIFF
--- a/server_ex/CHANGELOG.md
+++ b/server_ex/CHANGELOG.md
@@ -1,8 +1,19 @@
 # CHANGELOG
 
+## 0.3.1
+
+### Breaking changes
+
+- The `authorize/2` callback is deprecated in favor of `connect/2`, which can both authorize access and modify params.
+- Params passed to callbacks (`connect/2`, `init/1`) are now maps instead of keyword lists.
+
+### Fixes
+
+- Different route formats (`["foo", "bar"]` vs `"foo/bar"`) now correctly resolve to the same topic instance.
+
 ## 0.3.0
 
-### Featuyres
+### Features
 
 - Adds support for topics to have optional parameters (with defaults; in addition to required route parameters).
 

--- a/server_ex/lib/topical.ex
+++ b/server_ex/lib/topical.ex
@@ -41,7 +41,7 @@ defmodule Topical do
   ## Options
 
     * `params` - Optional map of params to pass to the topic (default: `%{}`).
-      These are merged with route params and passed to `init/1` and `authorize/2`.
+      These are merged with route params and passed to `connect/2` and `init/1`.
       Topics with different param values are separate instances and do not share state.
 
   ## Example
@@ -51,8 +51,9 @@ defmodule Topical do
 
   """
   def subscribe(registry, topic, pid, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <- Registry.resolve_topic(registry, topic, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key, context) do
+    with {:ok, module, all_params, topic_key} <-
+           Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
       # TODO: monitor/link server?
       ref = GenServer.call(server, {:subscribe, pid, context})
       {:ok, ref, server}
@@ -87,8 +88,9 @@ defmodule Topical do
       # => {:ok, %{items: %{}, order: []}}
   """
   def capture(registry, topic, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <- Registry.resolve_topic(registry, topic, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key, context) do
+    with {:ok, module, all_params, topic_key} <-
+           Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
       {:ok, GenServer.call(server, {:capture, context})}
     end
   end
@@ -107,8 +109,9 @@ defmodule Topical do
 
   """
   def execute(registry, topic, action, args \\ {}, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <- Registry.resolve_topic(registry, topic, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key, context) do
+    with {:ok, module, all_params, topic_key} <-
+           Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
       {:ok, GenServer.call(server, {:execute, action, args, context})}
     end
   end
@@ -129,8 +132,9 @@ defmodule Topical do
 
   """
   def notify(registry, topic, action, args \\ {}, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <- Registry.resolve_topic(registry, topic, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key, context) do
+    with {:ok, module, all_params, topic_key} <-
+           Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
       GenServer.cast(server, {:notify, action, args, context})
     end
   end

--- a/server_ex/lib/topical.ex
+++ b/server_ex/lib/topical.ex
@@ -51,9 +51,8 @@ defmodule Topical do
 
   """
   def subscribe(registry, topic, pid, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <-
-           Registry.resolve_topic(registry, topic, context, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
+    with {:ok, topic_key} <- Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, topic_key) do
       # TODO: monitor/link server?
       ref = GenServer.call(server, {:subscribe, pid, context})
       {:ok, ref, server}
@@ -88,9 +87,8 @@ defmodule Topical do
       # => {:ok, %{items: %{}, order: []}}
   """
   def capture(registry, topic, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <-
-           Registry.resolve_topic(registry, topic, context, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
+    with {:ok, topic_key} <- Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, topic_key) do
       {:ok, GenServer.call(server, {:capture, context})}
     end
   end
@@ -109,9 +107,8 @@ defmodule Topical do
 
   """
   def execute(registry, topic, action, args \\ {}, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <-
-           Registry.resolve_topic(registry, topic, context, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
+    with {:ok, topic_key} <- Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, topic_key) do
       {:ok, GenServer.call(server, {:execute, action, args, context})}
     end
   end
@@ -132,9 +129,8 @@ defmodule Topical do
 
   """
   def notify(registry, topic, action, args \\ {}, context \\ nil, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <-
-           Registry.resolve_topic(registry, topic, context, params),
-         {:ok, server} <- Registry.get_topic(registry, module, all_params, topic_key) do
+    with {:ok, topic_key} <- Registry.resolve_topic(registry, topic, context, params),
+         {:ok, server} <- Registry.get_topic(registry, topic_key) do
       GenServer.cast(server, {:notify, action, args, context})
     end
   end

--- a/server_ex/lib/topical/adapters/base/websocket.ex
+++ b/server_ex/lib/topical/adapters/base/websocket.ex
@@ -93,7 +93,7 @@ defmodule Topical.Adapters.Base.WebSocket do
 
   defp handle_subscribe(channel_id, topic, params, state) do
     # Resolve topic once - use for both alias detection and subscribing
-    case Registry.resolve_topic(state.registry, topic, params) do
+    case Registry.resolve_topic(state.registry, topic, state.context, params) do
       {:ok, module, all_params, topic_key} ->
         case Map.fetch(state.topic_keys, topic_key) do
           {:ok, existing_channel_id} ->
@@ -111,7 +111,7 @@ defmodule Topical.Adapters.Base.WebSocket do
   end
 
   defp do_subscribe(channel_id, module, all_params, topic_key, state) do
-    case Registry.get_topic(state.registry, module, all_params, topic_key, state.context) do
+    case Registry.get_topic(state.registry, module, all_params, topic_key) do
       {:ok, server} ->
         ref = GenServer.call(server, {:subscribe, self(), state.context})
 

--- a/server_ex/lib/topical/adapters/base/websocket.ex
+++ b/server_ex/lib/topical/adapters/base/websocket.ex
@@ -94,7 +94,7 @@ defmodule Topical.Adapters.Base.WebSocket do
   defp handle_subscribe(channel_id, topic, params, state) do
     # Resolve topic once - use for both alias detection and subscribing
     case Registry.resolve_topic(state.registry, topic, state.context, params) do
-      {:ok, module, all_params, topic_key} ->
+      {:ok, topic_key} ->
         case Map.fetch(state.topic_keys, topic_key) do
           {:ok, existing_channel_id} ->
             # Already subscribed to this topic - send alias response
@@ -102,7 +102,7 @@ defmodule Topical.Adapters.Base.WebSocket do
 
           :error ->
             # New subscription
-            do_subscribe(channel_id, module, all_params, topic_key, state)
+            do_subscribe(channel_id, topic_key, state)
         end
 
       {:error, error} ->
@@ -110,8 +110,8 @@ defmodule Topical.Adapters.Base.WebSocket do
     end
   end
 
-  defp do_subscribe(channel_id, module, all_params, topic_key, state) do
-    case Registry.get_topic(state.registry, module, all_params, topic_key) do
+  defp do_subscribe(channel_id, topic_key, state) do
+    case Registry.get_topic(state.registry, topic_key) do
       {:ok, server} ->
         ref = GenServer.call(server, {:subscribe, self(), state.context})
 

--- a/server_ex/lib/topical/adapters/cowboy/rest_handler.ex
+++ b/server_ex/lib/topical/adapters/cowboy/rest_handler.ex
@@ -43,6 +43,12 @@ defmodule Topical.Adapters.Cowboy.RestHandler do
 
           {:error, :not_found} ->
             {:ok, error_response(req, 404, "not_found"), opts}
+
+          {:error, :unauthorized} ->
+            {:ok, error_response(req, 403, "unauthorized"), opts}
+
+          {:error, error} ->
+            {:ok, error_response(req, 400, error), opts}
         end
     end
   end

--- a/server_ex/lib/topical/topic.ex
+++ b/server_ex/lib/topical/topic.ex
@@ -14,7 +14,7 @@ defmodule Topical.Topic do
 
         # Initialise the topic
         def init(params) do
-          list_id = Keyword.fetch!(params, :list_id)
+          list_id = Map.fetch!(params, :list_id)
 
           value = %{items: %{}, order: []} # exposed 'value' of the topic
           state = %{list_id: list_id} # hidden server state
@@ -108,9 +108,8 @@ defmodule Topical.Topic do
       end
 
       def connect(params, context) do
-        case authorize(params, context) do
-          :ok -> {:ok, params}
-          {:error, reason} -> {:error, reason}
+        with :ok <- authorize(params, context) do
+          {:ok, params}
         end
       end
 

--- a/server_ex/lib/topical/topic.ex
+++ b/server_ex/lib/topical/topic.ex
@@ -101,8 +101,17 @@ defmodule Topical.Topic do
         unquote(Keyword.get(opts, :params, []))
       end
 
+      @doc false
+      @deprecated "Use connect/2 instead"
       def authorize(_params, _context) do
         :ok
+      end
+
+      def connect(params, context) do
+        case authorize(params, context) do
+          :ok -> {:ok, params}
+          {:error, reason} -> {:error, reason}
+        end
       end
 
       def handle_subscribe(topic, _context) do
@@ -135,6 +144,7 @@ defmodule Topical.Topic do
       end
 
       defoverridable authorize: 2,
+                     connect: 2,
                      handle_subscribe: 2,
                      handle_unsubscribe: 2,
                      handle_capture: 2,

--- a/server_ex/lib/topical/topic/server.ex
+++ b/server_ex/lib/topical/topic/server.ex
@@ -8,11 +8,36 @@ defmodule Topical.Topic.Server do
   """
 
   @doc """
-  Invoked to check whether a client is authorized to access this topic.
+  Invoked when a client connects to this topic.
 
   `params` are the values associated with the placeholders in the route,
   merged with the request params (with defaults applied).
   `context` is the context established during the WebSocket connection.
+
+  Return `{:ok, params}` to allow access (optionally with modified params),
+  or `{:error, reason}` to deny. Modified params will affect topic identity -
+  topics with different param values are separate instances.
+
+  This is useful for incorporating context values (like user_id from auth)
+  into topic params for per-user or per-tenant topics.
+
+  This callback is optional. The default implementation delegates to
+  `authorize/2` for backwards compatibility.
+
+  ## Example
+
+      def connect(params, context) do
+        {:ok, Keyword.put(params, :user_id, context.user_id)}
+      end
+
+  """
+  @callback connect(params :: keyword(), context :: any) ::
+              {:ok, params :: keyword()} | {:error, reason :: any}
+
+  @doc """
+  Deprecated: Use `connect/2` instead.
+
+  Invoked to check whether a client is authorized to access this topic.
 
   Return `:ok` to allow access, or `{:error, reason}` to deny.
 

--- a/server_ex/lib/topical/topic/server.ex
+++ b/server_ex/lib/topical/topic/server.ex
@@ -10,8 +10,8 @@ defmodule Topical.Topic.Server do
   @doc """
   Invoked when a client connects to this topic.
 
-  `params` are the values associated with the placeholders in the route,
-  merged with the request params (with defaults applied).
+  `params` is a map containing the values associated with the placeholders in
+  the route, merged with the request params (with defaults applied).
   `context` is the context established during the WebSocket connection.
 
   Return `{:ok, params}` to allow access (optionally with modified params),
@@ -27,12 +27,12 @@ defmodule Topical.Topic.Server do
   ## Example
 
       def connect(params, context) do
-        {:ok, Keyword.put(params, :user_id, context.user_id)}
+        {:ok, Map.put(params, :user_id, context.user_id)}
       end
 
   """
-  @callback connect(params :: keyword(), context :: any) ::
-              {:ok, params :: keyword()} | {:error, reason :: any}
+  @callback connect(params :: map(), context :: any) ::
+              {:ok, params :: map()} | {:error, reason :: any}
 
   @doc """
   Deprecated: Use `connect/2` instead.
@@ -43,15 +43,15 @@ defmodule Topical.Topic.Server do
 
   This callback is optional. The default implementation returns `:ok`.
   """
-  @callback authorize(params :: keyword(), context :: any) :: :ok | {:error, reason :: any}
+  @callback authorize(params :: map(), context :: any) :: :ok | {:error, reason :: any}
 
   @doc """
   Invoked when the topic is started to get the initial state.
 
-  `params` are the values associated with the placeholders in the route,
-  merged with the request params (with defaults applied).
+  `params` is a map containing the values associated with the placeholders in
+  the route, merged with the request params (with defaults applied).
   """
-  @callback init(params :: keyword()) :: {:ok, %Topic{}} | {:error, reason :: any}
+  @callback init(params :: map()) :: {:ok, %Topic{}} | {:error, reason :: any}
 
   @doc """
   Invoked before a client subscribes (but after initialisation).

--- a/server_ex/mix.exs
+++ b/server_ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Topical.MixProject do
   def project do
     [
       app: :topical,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/server_ex/test/support/test_topics.ex
+++ b/server_ex/test/support/test_topics.ex
@@ -7,7 +7,7 @@ defmodule Topical.Test.CounterTopic do
   use Topical.Topic, route: ["counters", :id]
 
   def init(params) do
-    id = Keyword.fetch!(params, :id)
+    id = Map.fetch!(params, :id)
     value = %{count: 0}
     state = %{id: id}
     {:ok, Topic.new(value, state)}
@@ -55,7 +55,7 @@ defmodule Topical.Test.AuthorizedTopic do
   use Topical.Topic, route: ["private", :owner_id]
 
   def authorize(params, context) do
-    owner_id = Keyword.fetch!(params, :owner_id)
+    owner_id = Map.fetch!(params, :owner_id)
 
     cond do
       context == nil ->
@@ -70,7 +70,7 @@ defmodule Topical.Test.AuthorizedTopic do
   end
 
   def init(params) do
-    owner_id = Keyword.fetch!(params, :owner_id)
+    owner_id = Map.fetch!(params, :owner_id)
     value = %{owner: owner_id, data: nil}
     {:ok, Topic.new(value)}
   end
@@ -99,7 +99,7 @@ defmodule Topical.Test.CallbackTopic do
   use Topical.Topic, route: ["callbacks", :id]
 
   def init(params) do
-    id = Keyword.fetch!(params, :id)
+    id = Map.fetch!(params, :id)
     value = %{callbacks: []}
     state = %{id: id}
     {:ok, Topic.new(value, state)}
@@ -150,7 +150,7 @@ defmodule Topical.Test.FailingTopic do
   use Topical.Topic, route: ["failing", :id]
 
   def init(params) do
-    id = Keyword.fetch!(params, :id)
+    id = Map.fetch!(params, :id)
 
     case id do
       "init_error" ->
@@ -255,8 +255,8 @@ defmodule Topical.Test.LeaderboardTopic do
   use Topical.Topic, route: ["leaderboards", :game_id], params: [region: "global"]
 
   def init(params) do
-    game_id = Keyword.fetch!(params, :game_id)
-    region = Keyword.fetch!(params, :region)
+    game_id = Map.fetch!(params, :game_id)
+    region = Map.fetch!(params, :region)
 
     value = %{
       game_id: game_id,
@@ -300,7 +300,7 @@ defmodule Topical.Test.DocumentTopic do
   use Topical.Topic, route: ["documents", :doc_id], params: [mode: "view"]
 
   def authorize(params, context) do
-    mode = Keyword.fetch!(params, :mode)
+    mode = Map.fetch!(params, :mode)
 
     cond do
       mode == "edit" and context[:can_edit] != true ->
@@ -312,8 +312,8 @@ defmodule Topical.Test.DocumentTopic do
   end
 
   def init(params) do
-    doc_id = Keyword.fetch!(params, :doc_id)
-    mode = Keyword.fetch!(params, :mode)
+    doc_id = Map.fetch!(params, :doc_id)
+    mode = Map.fetch!(params, :mode)
 
     value = %{doc_id: doc_id, mode: mode, content: ""}
     {:ok, Topic.new(value)}

--- a/server_ex/test/topical/registry_test.exs
+++ b/server_ex/test/topical/registry_test.exs
@@ -7,9 +7,8 @@ defmodule Topical.RegistryTest do
 
   # Helper to resolve and get topic in one call (for test convenience)
   defp resolve_and_get_topic(registry, route, context, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <-
-           Registry.resolve_topic(registry, route, context, params) do
-      Registry.get_topic(registry, module, all_params, topic_key)
+    with {:ok, topic_key} <- Registry.resolve_topic(registry, route, context, params) do
+      Registry.get_topic(registry, topic_key)
     end
   end
 
@@ -93,6 +92,12 @@ defmodule Topical.RegistryTest do
     test "accepts string route format", %{registry: registry} do
       {:ok, pid} = resolve_and_get_topic(registry, "counters/1", nil)
       assert is_pid(pid)
+    end
+
+    test "returns same pid for list and string route formats", %{registry: registry} do
+      {:ok, pid1} = resolve_and_get_topic(registry, ["counters", "1"], nil)
+      {:ok, pid2} = resolve_and_get_topic(registry, "counters/1", nil)
+      assert pid1 == pid2
     end
 
     test "accepts URI-encoded route parts", %{registry: registry} do

--- a/server_ex/test/topical/registry_test.exs
+++ b/server_ex/test/topical/registry_test.exs
@@ -7,8 +7,9 @@ defmodule Topical.RegistryTest do
 
   # Helper to resolve and get topic in one call (for test convenience)
   defp resolve_and_get_topic(registry, route, context, params \\ %{}) do
-    with {:ok, module, all_params, topic_key} <- Registry.resolve_topic(registry, route, params) do
-      Registry.get_topic(registry, module, all_params, topic_key, context)
+    with {:ok, module, all_params, topic_key} <-
+           Registry.resolve_topic(registry, route, context, params) do
+      Registry.get_topic(registry, module, all_params, topic_key)
     end
   end
 
@@ -59,15 +60,16 @@ defmodule Topical.RegistryTest do
     end
 
     test "returns {:error, :not_found} for unknown route", %{registry: registry} do
-      assert {:error, :not_found} = Registry.resolve_topic(registry, ["unknown", "route"])
+      assert {:error, :not_found} = Registry.resolve_topic(registry, ["unknown", "route"], nil)
     end
 
     test "returns {:error, :not_found} for partial route match", %{registry: registry} do
-      assert {:error, :not_found} = Registry.resolve_topic(registry, ["counters"])
+      assert {:error, :not_found} = Registry.resolve_topic(registry, ["counters"], nil)
     end
 
     test "returns {:error, :not_found} for too long route", %{registry: registry} do
-      assert {:error, :not_found} = Registry.resolve_topic(registry, ["counters", "1", "extra"])
+      assert {:error, :not_found} =
+               Registry.resolve_topic(registry, ["counters", "1", "extra"], nil)
     end
 
     test "passes params to topic init", %{registry: registry} do


### PR DESCRIPTION
This updates topics so that they can define a `connect` callback, which replaces the now-deprecated `authorize` callback. The new callback can be used to implement authorisation, but also modify parameters before starting/using a topic. This can be useful to add parameters from the context (which itself can be populated from the HTTP request, using the adapter) - such as a tenant (or user) identifier, implicitly creating a separate topic instance for each.

This also tidies up the `params` so that they're represented a map rather than a keyword list.