### PR TITLE
Fix merge into undefined existing value

### DIFF
--- a/client_js/CHANGELOG.md
+++ b/client_js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.3.2
+
+### Fixes
+
+- Fix merging into undefined existing value.
+
 ## 0.3.1
 
 ### Features

--- a/client_js/package.json
+++ b/client_js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topical/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Vanilla Topical client.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/client_js/src/updates.ts
+++ b/client_js/src/updates.ts
@@ -82,12 +82,9 @@ export function applyUpdate<T>(current: T, update: Update): T {
     }
     case 4: {
       const [, path, value] = update;
-      return updateIn(current, path, (existing) => {
-        if (!isRecord(existing)) {
-          throw new Error("expected object");
-        }
-        return { ...existing, ...value };
-      }) as T;
+      return updateIn(current, path, (existing) =>
+        isRecord(existing) ? { ...existing, ...value } : { ...value }
+      ) as T;
     }
     default:
       throw new Error("unhandled update type");

--- a/client_js/src/updates.ts
+++ b/client_js/src/updates.ts
@@ -83,7 +83,7 @@ export function applyUpdate<T>(current: T, update: Update): T {
     case 4: {
       const [, path, value] = update;
       return updateIn(current, path, (existing) =>
-        isRecord(existing) ? { ...existing, ...value } : { ...value }
+        isRecord(existing) ? { ...existing, ...value } : { ...value },
       ) as T;
     }
     default:


### PR DESCRIPTION
This fixes an issue with handling merge updates, introduced in #7, where the value being updated is initially undefined.